### PR TITLE
Add a EffectTask<Action> typealias for Effect<Action, Never> and …

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -73,11 +73,15 @@
 		DC89C45524465C44006900B9 /* 02-Effects-Timers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC89C45424465C44006900B9 /* 02-Effects-Timers.swift */; };
 		DC9EB4172450CBD2005F413B /* UIViewRepresented.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9EB4162450CBD2005F413B /* UIViewRepresented.swift */; };
 		DCAC2A4F2452352E0094DEF5 /* 04-HigherOrderReducers-ElmLikeSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAC2A4E2452352E0094DEF5 /* 04-HigherOrderReducers-ElmLikeSubscriptions.swift */; };
+		DCC60D252895B1670005D514 /* 03-Navigation-Sheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC60D242895B1670005D514 /* 03-Navigation-Sheet.swift */; };
+		DCC60D272896C8250005D514 /* 03-Navigation-SheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC60D262896C8250005D514 /* 03-Navigation-SheetTests.swift */; };
 		DCC68EAB244666AF0037F998 /* 03-Navigation-Sheet-PresentAndLoad.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EAA244666AF0037F998 /* 03-Navigation-Sheet-PresentAndLoad.swift */; };
 		DCC68EDD2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EDC2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift */; };
 		DCC68EDF2447BC810037F998 /* TemplateText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EDE2447BC810037F998 /* TemplateText.swift */; };
 		DCC68EE12447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */; };
 		DCC68EE32447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */; };
+		DCCA5B0B2894CF7A005C1BD9 /* 03-Navigation-Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCA5B0A2894CF7A005C1BD9 /* 03-Navigation-Stack.swift */; };
+		DCCA5B0D2894CF98005C1BD9 /* 03-Navigation-StackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCA5B0C2894CF98005C1BD9 /* 03-Navigation-StackTests.swift */; };
 		DCD442C6286CA91F008B4EA7 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD442C5286CA91F008B4EA7 /* AboutView.swift */; };
 		DCE63B71245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */; };
 		DCFE1960278DBF0600C14CCF /* CaseStudiesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFE195F278DBF0600C14CCF /* CaseStudiesApp.swift */; };
@@ -226,11 +230,15 @@
 		DC89C45424465C44006900B9 /* 02-Effects-Timers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "02-Effects-Timers.swift"; sourceTree = "<group>"; };
 		DC9EB4162450CBD2005F413B /* UIViewRepresented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewRepresented.swift; sourceTree = "<group>"; };
 		DCAC2A4E2452352E0094DEF5 /* 04-HigherOrderReducers-ElmLikeSubscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ElmLikeSubscriptions.swift"; sourceTree = "<group>"; };
+		DCC60D242895B1670005D514 /* 03-Navigation-Sheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Navigation-Sheet.swift"; sourceTree = "<group>"; };
+		DCC60D262896C8250005D514 /* 03-Navigation-SheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Navigation-SheetTests.swift"; sourceTree = "<group>"; };
 		DCC68EAA244666AF0037F998 /* 03-Navigation-Sheet-PresentAndLoad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Navigation-Sheet-PresentAndLoad.swift"; sourceTree = "<group>"; };
 		DCC68EDC2447A5B00037F998 /* 01-GettingStarted-OptionalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-OptionalState.swift"; sourceTree = "<group>"; };
 		DCC68EDE2447BC810037F998 /* TemplateText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateText.swift; sourceTree = "<group>"; };
 		DCC68EE02447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-Composition-TwoCounters.swift"; sourceTree = "<group>"; };
 		DCC68EE22447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableFavoriting.swift"; sourceTree = "<group>"; };
+		DCCA5B0A2894CF7A005C1BD9 /* 03-Navigation-Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Navigation-Stack.swift"; sourceTree = "<group>"; };
+		DCCA5B0C2894CF98005C1BD9 /* 03-Navigation-StackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "03-Navigation-StackTests.swift"; sourceTree = "<group>"; };
 		DCD442C5286CA91F008B4EA7 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-Recursion.swift"; sourceTree = "<group>"; };
 		DCFE195F278DBF0600C14CCF /* CaseStudiesApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseStudiesApp.swift; sourceTree = "<group>"; };
@@ -416,6 +424,8 @@
 				DC89C44C244621A5006900B9 /* 03-Navigation-NavigateAndLoad.swift */,
 				DC072321244663B1003A8B65 /* 03-Navigation-Sheet-LoadThenPresent.swift */,
 				DCC68EAA244666AF0037F998 /* 03-Navigation-Sheet-PresentAndLoad.swift */,
+				DCC60D242895B1670005D514 /* 03-Navigation-Sheet.swift */,
+				DCCA5B0A2894CF7A005C1BD9 /* 03-Navigation-Stack.swift */,
 				DCAC2A4E2452352E0094DEF5 /* 04-HigherOrderReducers-ElmLikeSubscriptions.swift */,
 				CA3E4C5A24B4FA0E00447C0B /* 04-HigherOrderReducers-Lifecycle.swift */,
 				DCE63B70245CC0B90080A23D /* 04-HigherOrderReducers-Recursion.swift */,
@@ -442,6 +452,8 @@
 				CABC4F3A26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift */,
 				DC07231624465D1E003A8B65 /* 02-Effects-TimersTests.swift */,
 				CA410EE1247C73B400E41798 /* 02-Effects-WebSocketTests.swift */,
+				DCC60D262896C8250005D514 /* 03-Navigation-SheetTests.swift */,
+				DCCA5B0C2894CF98005C1BD9 /* 03-Navigation-StackTests.swift */,
 				CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */,
 				CA78F0CC28DA47D70026C4AD /* 04-HigherOrderReducers-RecursionTests.swift */,
 				DC634B242448D15B00DAA016 /* 04-HigherOrderReducers-ReusableFavoritingTests.swift */,
@@ -744,6 +756,7 @@
 				DC89C449244618D5006900B9 /* 03-Navigation-LoadThenNavigate.swift in Sources */,
 				DCC68EE12447C4630037F998 /* 01-GettingStarted-Composition-TwoCounters.swift in Sources */,
 				DC072322244663B1003A8B65 /* 03-Navigation-Sheet-LoadThenPresent.swift in Sources */,
+				DCCA5B0B2894CF7A005C1BD9 /* 03-Navigation-Stack.swift in Sources */,
 				DC89C45324465452006900B9 /* 03-Navigation-Lists-NavigateAndLoad.swift in Sources */,
 				CAF069D024ACC5AF00A1AAEF /* 00-Core.swift in Sources */,
 				DCC68EE32447C8540037F998 /* 04-HigherOrderReducers-ReusableFavoriting.swift in Sources */,
@@ -776,6 +789,7 @@
 				CAA9ADCA2446605B0003A984 /* 02-Effects-LongLiving.swift in Sources */,
 				DC89C45124462DE7006900B9 /* 03-Navigation-Lists-LoadThenNavigate.swift in Sources */,
 				DC89C45524465C44006900B9 /* 02-Effects-Timers.swift in Sources */,
+				DCC60D252895B1670005D514 /* 03-Navigation-Sheet.swift in Sources */,
 				CA410EE0247A15FE00E41798 /* 02-Effects-WebSocket.swift in Sources */,
 				CA7BC8EE245CCFE4001FB69F /* 01-GettingStarted-SharedState.swift in Sources */,
 			);
@@ -792,7 +806,9 @@
 				CA410EE2247C73B400E41798 /* 02-Effects-WebSocketTests.swift in Sources */,
 				CABC4F3B26AEE20200D5FA2C /* 02-Effects-RefreshableTests.swift in Sources */,
 				CA34170824A4E89500FAF950 /* 01-GettingStarted-AnimationsTests.swift in Sources */,
+				DCCA5B0D2894CF98005C1BD9 /* 03-Navigation-StackTests.swift in Sources */,
 				CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */,
+				DCC60D272896C8250005D514 /* 03-Navigation-SheetTests.swift in Sources */,
 				DC07231724465D1E003A8B65 /* 02-Effects-TimersTests.swift in Sources */,
 				CA50BE6024A8F46500FE7DBA /* 01-GettingStarted-AlertsAndConfirmationDialogsTests.swift in Sources */,
 				CAA9ADC424465AB00003A984 /* 02-Effects-BasicsTests.swift in Sources */,

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-Core.swift
@@ -20,8 +20,10 @@ struct Root: ReducerProtocol {
     var map = MapApp.State(cityMaps: .mocks)
     var navigateAndLoad = NavigateAndLoad.State()
     var navigateAndLoadList = NavigateAndLoadList.State()
+    var navigation = NavigationDemo.State()
     var nested = Nested.State.mock
     var optionalBasics = OptionalBasics.State()
+    var presentation = SheetDemo.State()
     var presentAndLoad = PresentAndLoad.State()
     var refreshable = Refreshable.State()
     var shared = SharedState.State()
@@ -49,9 +51,11 @@ struct Root: ReducerProtocol {
     case map(MapApp.Action)
     case navigateAndLoad(NavigateAndLoad.Action)
     case navigateAndLoadList(NavigateAndLoadList.Action)
+    case navigation(NavigationDemo.Action)
     case nested(Nested.Action)
     case optionalBasics(OptionalBasics.Action)
     case onAppear
+    case presentation(SheetDemo.Action)
     case presentAndLoad(PresentAndLoad.Action)
     case refreshable(Refreshable.Action)
     case shared(SharedState.Action)
@@ -128,11 +132,17 @@ struct Root: ReducerProtocol {
     Scope(state: \.navigateAndLoadList, action: /Action.navigateAndLoadList) {
       NavigateAndLoadList()
     }
+    Scope(state: \.navigation, action: /Action.navigation) {
+      NavigationDemo()
+    }
     Scope(state: \.nested, action: /Action.nested) {
       Nested()
     }
     Scope(state: \.optionalBasics, action: /Action.optionalBasics) {
       OptionalBasics()
+    }
+    Scope(state: \.presentation, action: /Action.presentation) {
+      SheetDemo()
     }
     Scope(state: \.presentAndLoad, action: /Action.presentAndLoad) {
       PresentAndLoad()

--- a/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -162,6 +162,26 @@ struct RootView: View {
 
         Section(header: Text("Navigation")) {
           NavigationLink(
+            "Navigation stack",
+            destination: NavigationDemoView(
+              store: self.store.scope(
+                state: \.navigation,
+                action: Root.Action.navigation
+              )
+            )
+          )
+
+          NavigationLink(
+            "Presentation sheet",
+            destination: SheetDemoView(
+              store: self.store.scope(
+                state: \.presentation,
+                action: Root.Action.presentation
+              )
+            )
+          )
+
+          NavigationLink(
             "Navigate and load data",
             destination: NavigateAndLoadView(
               store: self.store.scope(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -37,7 +37,7 @@ struct AlertAndConfirmationDialog: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertButtonTapped:
       state.alert = AlertState(

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -40,7 +40,7 @@ struct Animations: ReducerProtocol {
 
   @Dependency(\.mainQueue) var mainQueue
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     enum CancelID {}
 
     switch action {

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -35,7 +35,7 @@ struct BindingBasics: ReducerProtocol {
     case toggleChanged(isOn: Bool)
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case let .sliderValueChanged(value):
       state.sliderValue = value

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -21,7 +21,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift
@@ -88,7 +88,7 @@ struct SharedState: ReducerProtocol {
       case isPrimeButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .alertDismissed:
         state.alert = nil
@@ -140,7 +140,7 @@ struct SharedState: ReducerProtocol {
       case resetCounterButtonTapped
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       switch action {
       case .resetCounterButtonTapped:
         state.resetCount()

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -39,7 +39,7 @@ struct EffectsBasics: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum DelayID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -31,7 +31,7 @@ struct EffectsCancellation: ReducerProtocol {
   @Dependency(\.factClient) var factClient
   private enum NumberFactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
       state.isFactRequestInFlight = false

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -29,7 +29,7 @@ struct LongLivingEffects: ReducerProtocol {
 
   @Dependency(\.screenshots) var screenshots
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .task:
       // When the view appears, start the effect that emits when screenshots are taken.

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Refreshable.swift
@@ -31,7 +31,7 @@ struct Refreshable: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum FactRequestID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .cancelButtonTapped:
       return .cancel(id: FactRequestID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -26,7 +26,7 @@ struct Timers: ReducerProtocol {
   @Dependency(\.mainQueue) var mainQueue
   private enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .onDisappear:
       return .cancel(id: TimerID.self)

--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -40,7 +40,7 @@ struct WebSocket: ReducerProtocol {
   @Dependency(\.webSocket) var webSocket
   private enum WebSocketID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -18,7 +18,7 @@ struct LoadThenNavigateList: ReducerProtocol {
       Row(count: 42, id: UUID()),
       Row(count: 100, id: UUID()),
     ]
-    var selection: Identified<Row.ID, Counter.State>?
+    @PresentationStateOf<Counter> var selection
 
     struct Row: Equatable, Identifiable {
       var count: Int
@@ -28,10 +28,8 @@ struct LoadThenNavigateList: ReducerProtocol {
   }
 
   enum Action: Equatable {
-    case counter(Counter.Action)
-    case onDisappear
-    case setNavigation(selection: UUID?)
-    case setNavigationSelectionDelayCompleted(UUID)
+    case selection(PresentationActionOf<Counter>)
+    case selectionDelayCompleted(UUID)
   }
 
   @Dependency(\.mainQueue) var mainQueue
@@ -40,42 +38,31 @@ struct LoadThenNavigateList: ReducerProtocol {
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
-      case .counter:
-        return .none
+      case let .selection(.present(id as UUID, _)):
+        enum CancelID {}
 
-      case .onDisappear:
-        return .cancel(id: CancelID.self)
-
-      case let .setNavigation(selection: .some(navigatedId)):
         for row in state.rows {
-          state.rows[id: row.id]?.isActivityIndicatorVisible = row.id == navigatedId
+          state.rows[id: row.id]?.isActivityIndicatorVisible = row.id == id
         }
         return .task {
           try await self.mainQueue.sleep(for: 1)
-          return .setNavigationSelectionDelayCompleted(navigatedId)
+          return .selectionDelayCompleted(id)
         }
         .cancellable(id: CancelID.self, cancelInFlight: true)
 
-      case .setNavigation(selection: .none):
-        if let selection = state.selection {
-          state.rows[id: selection.id]?.count = selection.count
-        }
-        state.selection = nil
-        return .cancel(id: CancelID.self)
+      case .selection:
+        return .none
 
-      case let .setNavigationSelectionDelayCompleted(id):
+      case let .selectionDelayCompleted(id):
         state.rows[id: id]?.isActivityIndicatorVisible = false
-        state.selection = Identified(
-          Counter.State(count: state.rows[id: id]?.count ?? 0),
-          id: id
-        )
+        if let count = state.rows[id: id]?.count {
+          state.selection = Counter.State(count: count)
+        }
         return .none
       }
     }
-    .ifLet(\.selection, action: /Action.counter) {
-      Scope(state: \Identified<State.Row.ID, Counter.State>.value, action: /.self) {
-        Counter()
-      }
+    .presentationDestination(\.$selection, action: /Action.selection) {
+      Counter()
     }
   }
 }
@@ -92,21 +79,9 @@ struct LoadThenNavigateListView: View {
           AboutView(readMe: readMe)
         }
         ForEach(viewStore.rows) { row in
-          NavigationLink(
-            destination: IfLetStore(
-              self.store.scope(
-                state: \.selection?.value,
-                action: LoadThenNavigateList.Action.counter
-              )
-            ) {
-              CounterView(store: $0)
-            },
-            tag: row.id,
-            selection: viewStore.binding(
-              get: \.selection?.id,
-              send: LoadThenNavigateList.Action.setNavigation(selection:)
-            )
-          ) {
+          Button {
+            viewStore.send(.selection(.present(id: row.id)))
+          } label: {
             HStack {
               Text("Load optional counter that starts from \(row.count)")
               if row.isActivityIndicatorVisible {
@@ -117,8 +92,14 @@ struct LoadThenNavigateListView: View {
           }
         }
       }
+      .navigationDestination(
+        store: self.store.scope(
+          state: \.$selection,
+          action: LoadThenNavigateList.Action.selection
+        ),
+        destination: CounterView.init(store:)
+      )
       .navigationTitle("Load then navigate")
-      .onDisappear { viewStore.send(.onDisappear) }
     }
   }
 }
@@ -127,7 +108,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateList.State(

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -13,17 +13,13 @@ private let readMe = """
 
 struct LoadThenPresent: ReducerProtocol {
   struct State: Equatable {
-    var optionalCounter: Counter.State?
+    @PresentationStateOf<Counter> var counter
     var isActivityIndicatorVisible = false
-
-    var isSheetPresented: Bool { self.optionalCounter != nil }
   }
 
   enum Action {
-    case onDisappear
-    case optionalCounter(Counter.Action)
-    case setSheet(isPresented: Bool)
-    case setSheetIsPresentedDelayCompleted
+    case counter(PresentationActionOf<Counter>)
+    case presentationDelayCompleted
   }
 
   @Dependency(\.mainQueue) var mainQueue
@@ -32,31 +28,23 @@ struct LoadThenPresent: ReducerProtocol {
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
-      case .onDisappear:
-        return .cancel(id: CancelID.self)
-
-      case .setSheet(isPresented: true):
+      case .counter(.present):
         state.isActivityIndicatorVisible = true
         return .task {
           try await self.mainQueue.sleep(for: 1)
-          return .setSheetIsPresentedDelayCompleted
+          return .presentationDelayCompleted
         }
-        .cancellable(id: CancelID.self)
 
-      case .setSheet(isPresented: false):
-        state.optionalCounter = nil
+      case .counter:
         return .none
 
-      case .setSheetIsPresentedDelayCompleted:
+      case .presentationDelayCompleted:
+        state.counter = Counter.State()
         state.isActivityIndicatorVisible = false
-        state.optionalCounter = Counter.State()
-        return .none
-
-      case .optionalCounter:
         return .none
       }
     }
-    .ifLet(\.optionalCounter, action: /Action.optionalCounter) {
+    .presentationDestination(\.$counter, action: /Action.counter) {
       Counter()
     }
   }
@@ -73,7 +61,9 @@ struct LoadThenPresentView: View {
         Section {
           AboutView(readMe: readMe)
         }
-        Button(action: { viewStore.send(.setSheet(isPresented: true)) }) {
+        Button {
+          viewStore.send(.counter(.present))
+        } label: {
           HStack {
             Text("Load optional counter")
             if viewStore.isActivityIndicatorVisible {
@@ -83,23 +73,11 @@ struct LoadThenPresentView: View {
           }
         }
       }
-      .sheet(
-        isPresented: viewStore.binding(
-          get: \.isSheetPresented,
-          send: LoadThenPresent.Action.setSheet(isPresented:)
-        )
-      ) {
-        IfLetStore(
-          self.store.scope(
-            state: \.optionalCounter,
-            action: LoadThenPresent.Action.optionalCounter
-          )
-        ) {
-          CounterView(store: $0)
-        }
-      }
       .navigationTitle("Load and present")
-      .onDisappear { viewStore.send(.onDisappear) }
+      .sheet(
+        store: self.store.scope(state: \.$counter, action: LoadThenPresent.Action.counter),
+        content: CounterView.init(store:)
+      )
     }
   }
 }

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet.swift
@@ -1,0 +1,167 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct SheetDemo: ReducerProtocol {
+  struct State: Equatable {
+    @PresentationStateOf<Destinations> var sheet
+  }
+
+  enum Action: Equatable {
+    case sheet(PresentationActionOf<Destinations>)
+    case swap
+  }
+
+  var body: some ReducerProtocol<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .sheet(.presented(.counter(.decrementButtonTapped))):
+        state.sheet = .counter(Counter.State())
+        return .none
+
+      case .sheet:
+        return .none
+
+      case .swap:
+        switch state.sheet {
+        case .some(.animations):
+          state.sheet = .counter(Counter.State())
+        case .some(.counter):
+          state.sheet = .animations(Animations.State())
+        case .none:
+          break
+        }
+        return .none
+      }
+    }
+    .presentationDestination(\.$sheet, action: /Action.sheet) {
+      Destinations()
+    }
+  }
+
+  struct Destinations: ReducerProtocol {
+    enum State: Equatable {
+      case animations(Animations.State)
+      case counter(Counter.State)
+    }
+
+    enum Action: Equatable {
+      case animations(Animations.Action)
+      case counter(Counter.Action)
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Scope(
+        state: /State.animations,
+        action: /Action.animations
+      ) {
+        Animations()
+      }
+      Scope(
+        state: /State.counter,
+        action: /Action.counter
+      ) {
+        Counter()
+      }
+    }
+  }
+}
+
+struct SheetDemoView: View {
+  let store: StoreOf<SheetDemo>
+
+  var body: some View {
+    WithViewStore(self.store.stateless) { viewStore in
+      Form {
+        Button("Animations") {
+          viewStore.send(.sheet(.present(.animations(Animations.State()))))
+        }
+        Button("Counter") {
+          viewStore.send(.sheet(.present(.counter(Counter.State()))))
+        }
+      }
+      //      .sheet(
+      //        store: self.store.scope(state: \.$sheet, action: SheetDemo.Action.sheet)
+      //      ) { store in
+      //        VStack {
+      //          HStack {
+      //            Button("Swap") {
+      //              viewStore.send(.swap, animation: .default)
+      //            }
+      //            Button("Close") {
+      //              viewStore.send(.sheet(.dismiss))
+      //            }
+      //          }
+      //          .padding()
+      //
+      //          SwitchStore(store) {
+      //            CaseLet(
+      //              state: /SheetDemo.Destinations.State.animations,
+      //              action: SheetDemo.Destinations.Action.animations,
+      //              then: AnimationsView.init(store:)
+      //            )
+      //            CaseLet(
+      //              state: /SheetDemo.Destinations.State.counter,
+      //              action: SheetDemo.Destinations.Action.counter,
+      //              then: CounterView.init(store:)
+      //            )
+      //          }
+      //          .transition(.slide.combined(with: .opacity))
+      //
+      //          Spacer()
+      //        }
+      //      }
+      .sheet(
+        store: self.store.scope(state: \.$sheet, action: SheetDemo.Action.sheet),
+        state: /SheetDemo.Destinations.State.animations,
+        action: SheetDemo.Destinations.Action.animations
+      ) { store in
+        VStack {
+          HStack {
+            Button("Swap") {
+              viewStore.send(.swap, animation: .default)
+            }
+            Button("Close") {
+              viewStore.send(.sheet(.dismiss))
+            }
+          }
+          .padding()
+
+          AnimationsView(store: store)
+          Spacer()
+        }
+      }
+      .sheet(
+        store: self.store.scope(state: \.$sheet, action: SheetDemo.Action.sheet),
+        state: /SheetDemo.Destinations.State.counter,
+        action: SheetDemo.Destinations.Action.counter
+      ) { store in
+        VStack {
+          HStack {
+            Button("Swap") {
+              viewStore.send(.swap, animation: .default)
+            }
+            Button("Close") {
+              viewStore.send(.sheet(.dismiss))
+            }
+          }
+          .padding()
+
+          CounterView(store: store)
+          Spacer()
+        }
+      }
+    }
+    .navigationTitle("Sheets")
+  }
+}
+
+struct SheetDemo_Previews: PreviewProvider {
+  static var previews: some View {
+    SheetDemoView(
+      store: Store(
+        initialState: SheetDemo.State(),
+        reducer: SheetDemo()
+      )
+    )
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Stack.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Stack.swift
@@ -1,0 +1,478 @@
+import ComposableArchitecture
+import SwiftUI
+
+private let readMe = """
+  This screen demonstrates how to use NavigationStack with Composable Architecture applications.
+  """
+
+struct NavigationDemo: ReducerProtocol {
+  struct State: Equatable {
+    @NavigationStateOf<Destinations> var path
+  }
+
+  enum Action: Equatable {
+    case goBackToScreen(Int)
+    case goToABCButtonTapped
+    case path(NavigationActionOf<Destinations>)
+    case shuffleButtonTapped
+    case cancelTimersButtonTapped
+  }
+
+  var body: some ReducerProtocol<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .cancelTimersButtonTapped:
+        return .merge(
+          state.$path.compactMap { destination in
+            switch destination.element {
+            case .screenA, .screenB:
+              return nil
+
+            case .screenC:
+              return .cancel(id: destination.id)
+            }
+          })
+
+      case let .goBackToScreen(n):
+        state.path.removeLast(n)
+        return .none
+
+      case .goToABCButtonTapped:
+        state.path.append(.screenA(.init()))
+        state.path.append(.screenB(.init()))
+        state.path.append(.screenC(.init()))
+        return .none
+
+      case .path(.element(id: _, .screenB(.screenAButtonTapped))):
+        state.path.append(.screenA(.init()))
+        return .none
+
+      case .path(.element(id: _, .screenB(.screenBButtonTapped))):
+        state.path.append(.screenB(.init()))
+        return .none
+
+      case .path(.element(id: _, .screenB(.screenCButtonTapped))):
+        state.path.append(.screenC(.init()))
+        return .none
+
+      case .path:
+        return .none
+
+      case .shuffleButtonTapped:
+        state.path.shuffle()
+        return .none
+      }
+    }
+    .navigationDestination(\.$path, action: /Action.path) {
+      Destinations()
+    }
+  }
+
+  struct Destinations: ReducerProtocol {
+    enum State: Codable, Equatable, Hashable {
+      case screenA(ScreenA.State)
+      case screenB(ScreenB.State)
+      case screenC(ScreenC.State)
+    }
+
+    enum Action: Equatable {
+      case screenA(ScreenA.Action)
+      case screenB(ScreenB.Action)
+      case screenC(ScreenC.Action)
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Scope(
+        state: /State.screenA,
+        action: /Action.screenA
+      ) {
+        ScreenA()
+      }
+      Scope(
+        state: /State.screenB,
+        action: /Action.screenB
+      ) {
+        ScreenB()
+      }
+      Scope(
+        state: /State.screenC,
+        action: /Action.screenC
+      ) {
+        ScreenC()
+      }
+    }
+  }
+}
+
+struct NavigationDemoView: View {
+  let store: StoreOf<NavigationDemo>
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      NavigationStackStore(self.store.scope(state: \.$path, action: NavigationDemo.Action.path)) {
+        Form {
+          Section { Text(readMe) }
+
+          Section {
+            NavigationLink(
+              "Go to screen A",
+              state: NavigationDemo.Destinations.State.screenA(.init())
+            )
+            NavigationLink(
+              "Go to screen B",
+              state: NavigationDemo.Destinations.State.screenB(.init())
+            )
+            NavigationLink(
+              "Go to screen C",
+              state: NavigationDemo.Destinations.State.screenC(.init())
+            )
+          }
+
+          WithViewStore(self.store.stateless) { viewStore in
+            Section {
+              Button("Go to A → B → C") {
+                viewStore.send(.goToABCButtonTapped)
+              }
+            }
+          }
+        }
+        .navigationDestination(
+          store: self.store.scope(state: \.$path, action: NavigationDemo.Action.path)
+        ) { store in
+          SwitchStore(store) {
+            CaseLet(
+              state: /NavigationDemo.Destinations.State.screenA,
+              action: NavigationDemo.Destinations.Action.screenA,
+              then: ScreenAView.init(store:)
+            )
+            CaseLet(
+              state: /NavigationDemo.Destinations.State.screenB,
+              action: NavigationDemo.Destinations.Action.screenB,
+              then: ScreenBView.init(store:)
+            )
+            CaseLet(
+              state: /NavigationDemo.Destinations.State.screenC,
+              action: NavigationDemo.Destinations.Action.screenC,
+              then: ScreenCView.init(store:)
+            )
+          }
+        }
+        .navigationTitle("Root")
+      }
+      .zIndex(0)
+
+      FloatingMenuView(store: self.store)
+        .zIndex(1)
+    }
+    .navigationTitle("Navigation Stack")
+  }
+}
+
+struct FloatingMenuView: View {
+  let store: StoreOf<NavigationDemo>
+
+  struct State: Equatable {
+    var currentStack: [String]
+    var total: Int
+    init(state: NavigationDemo.State) {
+      self.total = 0
+      self.currentStack = []
+      for element in state.path {
+        switch element {
+        case let .screenA(screenAState):
+          self.total += screenAState.count
+          self.currentStack.insert("Screen A", at: 0)
+        case .screenB:
+          self.currentStack.insert("Screen B", at: 0)
+        case let .screenC(screenBState):
+          self.total += screenBState.count
+          self.currentStack.insert("Screen C", at: 0)
+        }
+      }
+    }
+  }
+
+  var body: some View {
+    WithViewStore(self.store.scope(state: State.init)) { viewStore in
+      if viewStore.currentStack.count > 0 {
+        VStack(alignment: .leading) {
+          Text("Total count: \(viewStore.total)")
+          Button("Shuffle navigation stack") {
+            viewStore.send(.shuffleButtonTapped)
+          }
+          Button("Pop to root") {
+            viewStore.send(.path(.setPath([:])))
+          }
+          Button("Cancel timers") {
+            viewStore.send(.cancelTimersButtonTapped)
+          }
+
+          Menu {
+            ForEach(Array(viewStore.currentStack.enumerated()), id: \.offset) { offset, screen in
+              Button("\(viewStore.currentStack.count - offset).) \(screen)") {
+                viewStore.send(.goBackToScreen(offset))
+              }
+              .disabled(offset == 0)
+            }
+            Button("Root") { viewStore.send(.path(.setPath([:]))) }
+          } label: {
+            Text("Current stack")
+          }
+        }
+        .padding()
+        .background(Color.white)
+        .padding(.bottom, 1)
+        .transition(.opacity.animation(.default))
+      }
+    }
+    .debug()
+  }
+}
+
+// MARK: - Screen A
+
+struct ScreenA: ReducerProtocol {
+  struct State: Codable, Equatable, Hashable {
+    var count = 0
+    var fact: String?
+    var isLoading = false
+  }
+
+  enum Action: Equatable {
+    case decrementButtonTapped
+    case incrementButtonTapped
+    case factButtonTapped
+    case factResponse(TaskResult<String>)
+  }
+
+  @Dependency(\.factClient) var factClient
+
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    switch action {
+    case .decrementButtonTapped:
+      state.count -= 1
+      return .none
+
+    case .incrementButtonTapped:
+      state.count += 1
+      return .none
+
+    case .factButtonTapped:
+      state.isLoading = true
+      return .task { [count = state.count] in
+        await .factResponse(.init { try await self.factClient.fetch(count) })
+      }
+
+    case let .factResponse(.success(fact)):
+      state.isLoading = false
+      state.fact = fact
+      return .none
+
+    case .factResponse(.failure):
+      state.isLoading = false
+      state.fact = nil
+      // TODO: Error handling?
+      return .none
+    }
+  }
+}
+
+struct ScreenAView: View {
+  let store: StoreOf<ScreenA>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      Form {
+        Section {
+          HStack {
+            Text("\(viewStore.count)")
+            Spacer()
+            Button {
+              viewStore.send(.decrementButtonTapped)
+            } label: {
+              Image(systemName: "minus")
+            }
+            Button {
+              viewStore.send(.incrementButtonTapped)
+            } label: {
+              Image(systemName: "plus")
+            }
+          }
+          .buttonStyle(.borderless)
+
+          Button(action: { viewStore.send(.factButtonTapped) }) {
+            HStack {
+              Text("Get fact")
+              Spacer()
+              if viewStore.isLoading {
+                ProgressView()
+              }
+            }
+          }
+
+          if let fact = viewStore.fact {
+            Text(fact)
+          }
+        }
+
+        Section {
+          NavigationLink(
+            "Go to screen A",
+            state: NavigationDemo.Destinations.State.screenA(.init(count: viewStore.count))
+          )
+          NavigationLink(
+            "Go to screen B",
+            state: NavigationDemo.Destinations.State.screenB(.init())
+          )
+          NavigationLink(
+            "Go to screen C",
+            state: NavigationDemo.Destinations.State.screenC(.init())
+          )
+        }
+      }
+    }
+    .navigationTitle("Screen A")
+  }
+}
+
+// MARK: - Screen B
+
+struct ScreenB: ReducerProtocol {
+  struct State: Codable, Equatable, Hashable {}
+
+  enum Action: Equatable {
+    case dismissButtonTapped
+    case screenAButtonTapped
+    case screenBButtonTapped
+    case screenCButtonTapped
+  }
+
+  @Dependency(\.dismiss) var dismiss
+
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    switch action {
+    case .dismissButtonTapped:
+      return .fireAndForget {
+        await self.dismiss()
+      }
+    case .screenAButtonTapped:
+      return .none
+    case .screenBButtonTapped:
+      return .none
+    case .screenCButtonTapped:
+      return .none
+    }
+  }
+}
+
+struct ScreenBView: View {
+  let store: StoreOf<ScreenB>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      Form {
+        Button("Dismiss") {
+          viewStore.send(.dismissButtonTapped)
+        }
+        Button("Decoupled navigation to screen A") {
+          viewStore.send(.screenAButtonTapped)
+        }
+        Button("Decoupled navigation to screen B") {
+          viewStore.send(.screenBButtonTapped)
+        }
+        Button("Decoupled navigation to screen C") {
+          viewStore.send(.screenCButtonTapped)
+        }
+      }
+      .navigationTitle("Screen B")
+    }
+  }
+}
+
+// MARK: - Screen C
+
+struct ScreenC: ReducerProtocol {
+  struct State: Codable, Equatable, Hashable {
+    var count = 0
+    var isTimerRunning = false
+  }
+
+  enum Action: Equatable {
+    case startButtonTapped
+    case stopButtonTapped
+    case timerTick
+  }
+
+  @Dependency(\.mainQueue) var mainQueue
+
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+    enum TimerID {}
+
+    switch action {
+    case .startButtonTapped:
+      state.isTimerRunning = true
+      return .run { send in
+        for await _ in self.mainQueue.timer(interval: 1) {
+          await send(.timerTick)
+        }
+      }
+      .cancellable(id: TimerID.self)
+
+    case .stopButtonTapped:
+      state.isTimerRunning = false
+      return .cancel(id: TimerID.self)
+
+    case .timerTick:
+      state.count += 1
+      return .none
+    }
+  }
+}
+
+struct ScreenCView: View {
+  let store: StoreOf<ScreenC>
+
+  var body: some View {
+    WithViewStore(self.store) { viewStore in
+      Form {
+        Section {
+          Text("\(viewStore.count)")
+          if viewStore.isTimerRunning {
+            Button("Stop timer") { viewStore.send(.stopButtonTapped) }
+          } else {
+            Button("Start timer") { viewStore.send(.startButtonTapped) }
+          }
+        }
+
+        Section {
+          NavigationLink(
+            "Go to screen A",
+            state: NavigationDemo.Destinations.State.screenA(.init(count: viewStore.count))
+          )
+          NavigationLink(
+            "Go to screen B",
+            state: NavigationDemo.Destinations.State.screenB(.init())
+          )
+          NavigationLink(
+            "Go to screen C",
+            state: NavigationDemo.Destinations.State.screenC(.init())
+          )
+        }
+      }
+      .navigationTitle("Screen C")
+    }
+  }
+}
+
+// MARK: - Previews
+
+struct NavigationStack_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationDemoView(
+      store: Store(
+        initialState: NavigationDemo.State(),
+        reducer: NavigationDemo()
+      )
+    )
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -11,9 +11,9 @@ private let readMe = """
 
 extension AnyReducer {
   static func subscriptions(
-    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: Effect<Action, Never>]
+    _ subscriptions: @escaping (State, Environment) -> [AnyHashable: EffectTask<Action>]
   ) -> Self {
-    var activeSubscriptions: [AnyHashable: Effect<Action, Never>] = [:]
+    var activeSubscriptions: [AnyHashable: EffectTask<Action>] = [:]
 
     return AnyReducer { state, _, environment in
       let currentSubscriptions = subscriptions(state, environment)

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -19,8 +19,8 @@ struct LifecycleReducer<Wrapped: ReducerProtocol>: ReducerProtocol {
   }
 
   let wrapped: Wrapped
-  let onAppear: Effect<Wrapped.Action, Never>
-  let onDisappear: Effect<Never, Never>
+  let onAppear: EffectTask<Wrapped.Action>
+  let onDisappear: EffectTask<Never>
 
   var body: some ReducerProtocol<Wrapped.State?, Action> {
     Reduce { state, lifecycleAction in
@@ -45,8 +45,8 @@ extension LifecycleReducer.Action: Equatable where Wrapped.Action: Equatable {}
 
 extension ReducerProtocol {
   func lifecycle(
-    onAppear: Effect<Action, Never>,
-    onDisappear: Effect<Never, Never> = .none
+    onAppear: EffectTask<Action>,
+    onDisappear: EffectTask<Never> = .none
   ) -> LifecycleReducer<Self> {
     LifecycleReducer(wrapped: self, onAppear: onAppear, onDisappear: onDisappear)
   }

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/DownloadComponent.swift
@@ -24,7 +24,7 @@ struct DownloadComponent: ReducerProtocol {
 
   @Dependency(\.downloadClient) var downloadClient
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alert(.deleteButtonTapped):
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -40,7 +40,7 @@ struct Favoriting<ID: Hashable & Sendable>: ReducerProtocol {
 
   func reduce(
     into state: inout FavoritingState<ID>, action: FavoritingAction
-  ) -> Effect<FavoritingAction, Never> {
+  ) -> EffectTask<FavoritingAction> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Navigation-SheetTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Navigation-SheetTests.swift
@@ -1,0 +1,37 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+@testable import SwiftUICaseStudies
+
+@MainActor
+class NavigationSheetTests: XCTestCase {
+  func testBasics() async {
+    let store = TestStore(
+      initialState: SheetDemo.State(),
+      reducer: SheetDemo()
+    )
+
+    let mainQueue = DispatchQueue.test
+    store.dependencies.mainQueue = mainQueue.eraseToAnyScheduler()
+
+    await store.send(.sheet(.present(.animations(Animations.State())))) {
+      $0.sheet = .animations(Animations.State())
+    }
+    await store.send(.sheet(.presented(.animations(.rainbowButtonTapped))))
+    await store.receive(.sheet(.presented(.animations(.setColor(.red))))) {
+      try (/Optional.some).appending(path: /SheetDemo.Destinations.State.animations)
+        .modify(&$0.sheet) { $0.circleColor = .red }
+    }
+
+    await mainQueue.advance(by: .seconds(1))
+    await store.receive(.sheet(.presented(.animations(.setColor(.blue))))) {
+      try (/Optional.some).appending(path: /SheetDemo.Destinations.State.animations)
+        .modify(&$0.sheet) { $0.circleColor = .blue }
+    }
+
+    await store.send(.sheet(.dismiss)) {
+      $0.sheet = nil
+    }
+  }
+}

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Navigation-StackTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/03-Navigation-StackTests.swift
@@ -1,0 +1,107 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+
+@testable import SwiftUICaseStudies
+
+@MainActor
+class NavigationStackTests: XCTestCase {
+  let scheduler = DispatchQueue.test
+
+  func testBasics() async {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: NavigationDemo()
+        .dependency(\.factClient.fetch) { "\($0) is a good number." }
+        .dependency(\.mainQueue, self.scheduler.eraseToAnyScheduler())
+    )
+
+    // Push Screen A, increment and fetch fact.
+    let screenAID = store.dependencies.navigationID.next()
+    await store.send(.path(.setPath([screenAID: .screenA(.init())]))) {
+      $0.$path = [screenAID: .screenA(.init())]
+    }
+    await store.send(.path(.element(id: screenAID, .screenA(.incrementButtonTapped)))) {
+      try CasePath(NavigationDemo.Destinations.State.screenA).unwrapModify(&$0.$path[id: screenAID])
+      {
+        $0.count = 1
+      }
+    }
+    await store.send(.path(.element(id: screenAID, .screenA(.factButtonTapped)))) {
+      try CasePath(NavigationDemo.Destinations.State.screenA).unwrapModify(&$0.$path[id: screenAID])
+      {
+        $0.isLoading = true
+      }
+    }
+    await self.scheduler.advance()
+    await store.receive(
+      .path(.element(id: screenAID, .screenA(.factResponse(.success("1 is a good number.")))))
+    ) {
+      try CasePath(NavigationDemo.Destinations.State.screenA).unwrapModify(&$0.$path[id: screenAID])
+      {
+        $0.isLoading = false
+        $0.fact = "1 is a good number."
+      }
+    }
+
+    // Push Screen C, start timer, wait 2 seconds
+    let screenCID = store.dependencies.navigationID.next()
+    await store.send(.path(.setPath(store.state.$path + [screenCID: .screenC(.init())]))) {
+      $0.$path.append(.init(id: screenCID, element: .screenC(.init())))
+    }
+    await store.send(.path(.element(id: screenCID, .screenC(.startButtonTapped)))) {
+      try CasePath(NavigationDemo.Destinations.State.screenC).unwrapModify(&$0.$path[id: screenCID])
+      {
+        $0.isTimerRunning = true
+      }
+    }
+    await self.scheduler.advance(by: .seconds(2))
+    await store.receive(.path(.element(id: screenCID, .screenC(.timerTick)))) {
+      try CasePath(NavigationDemo.Destinations.State.screenC).unwrapModify(&$0.$path[id: screenCID])
+      {
+        $0.count = 1
+      }
+    }
+    await store.receive(.path(.element(id: screenCID, .screenC(.timerTick)))) {
+      try CasePath(NavigationDemo.Destinations.State.screenC).unwrapModify(&$0.$path[id: screenCID])
+      {
+        $0.count = 2
+      }
+    }
+
+    // Pop screen C off stack
+    var path = store.state.$path
+    path.removeLast()
+    await store.send(.path(.setPath(path))) {
+      $0.path.removeLast()
+    }
+  }
+
+  func testProgrammaticNavigation() async {
+    let store = TestStore(
+      initialState: .init(),
+      reducer: NavigationDemo()
+        .dependency(\.factClient.fetch) { "\($0) is a good number." }
+        .dependency(\.mainQueue, self.scheduler.eraseToAnyScheduler())
+    )
+
+    let screenBID = store.dependencies.navigationID.next()
+    await store.send(.path(.setPath([screenBID: .screenB(.init())]))) {
+      $0.$path = [screenBID: .screenB(.init())]
+    }
+
+    await store.send(.path(.element(id: screenBID, .screenB(.screenAButtonTapped)))) {
+      $0.$path.append(.init(id: 1, element: .screenA(.init())))
+    }
+  }
+}
+
+// TODO: move to swift-case-paths?
+extension CasePath {
+  public func unwrapModify<Result>(
+    _ root: inout Root?,
+    _ body: (inout Value) throws -> Result
+  ) throws -> Result {
+    return try CasePath<Root?, Root>(Optional.some).appending(path: self).modify(&root, body)
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -14,7 +14,7 @@ struct Counter: ReducerProtocol {
     case incrementButtonTapped
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .decrementButtonTapped:
       state.count -= 1

--- a/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
+++ b/Examples/CaseStudies/tvOSCaseStudies/FocusView.swift
@@ -21,7 +21,7 @@ struct Focus: ReducerProtocol {
 
   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .randomButtonClicked:
       state.currentFocus = self.withRandomNumberGenerator {

--- a/Examples/Search/Search/SearchView.swift
+++ b/Examples/Search/Search/SearchView.swift
@@ -42,7 +42,7 @@ struct Search: ReducerProtocol {
   private enum SearchLocationID {}
   private enum SearchWeatherID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .forecastResponse(_, .failure):
       state.weather = nil

--- a/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
+++ b/Examples/SpeechRecognition/SpeechRecognition/SpeechRecognition.swift
@@ -24,7 +24,7 @@ struct SpeechRecognition: ReducerProtocol {
 
   @Dependency(\.speechClient) var speechClient
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .authorizationStateAlertDismissed:
       state.alert = nil

--- a/Examples/TicTacToe/tic-tac-toe/Package.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
   name: "tic-tac-toe",
   platforms: [
-    .iOS(.v14)
+    .iOS(.v16)
   ],
   products: [
     .library(name: "AppCore", targets: ["AppCore"]),

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppCore/AppCore.swift
@@ -22,7 +22,7 @@ public struct TicTacToe: ReducerProtocol {
   public var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
-      case .login(.twoFactor(.twoFactorResponse(.success))):
+      case .login(.twoFactor(.presented(.twoFactorResponse(.success)))):
         state = .newGame(NewGame.State())
         return .none
 

--- a/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,16 +14,14 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /TicTacToe.State.login, action: TicTacToe.Action.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
-        .navigationViewStyle(.stack)
       }
       CaseLet(state: /TicTacToe.State.newGame, action: TicTacToe.Action.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
-        .navigationViewStyle(.stack)
       }
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -29,7 +29,7 @@ public struct Game: ReducerProtocol {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case let .cellTapped(row, column):
       guard

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameCore/GameCore.swift
@@ -24,7 +24,6 @@ public struct Game: ReducerProtocol {
   public enum Action: Equatable, Sendable {
     case cellTapped(row: Int, column: Int)
     case playAgainButtonTapped
-    case quitButtonTapped
   }
 
   public init() {}
@@ -47,9 +46,6 @@ public struct Game: ReducerProtocol {
 
     case .playAgainButtonTapped:
       state = Game.State(oPlayerName: state.oPlayerName, xPlayerName: state.xPlayerName)
-      return .none
-
-    case .quitButtonTapped:
       return .none
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -3,6 +3,8 @@ import GameCore
 import SwiftUI
 
 public struct GameView: View {
+  @Environment(\.dismiss) var dismiss
+
   let store: StoreOf<Game>
 
   struct ViewState: Equatable, Sendable {
@@ -54,7 +56,7 @@ public struct GameView: View {
           .disabled(viewStore.isGameDisabled)
         }
         .navigationTitle("Tic-tac-toe")
-        .navigationBarItems(leading: Button("Quit") { viewStore.send(.quitButtonTapped) })
+        .navigationBarItems(leading: Button("Quit") { self.dismiss() })
         .navigationBarBackButtonHidden(true)
       }
     }
@@ -94,7 +96,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: Game.State(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/GameUIKit/GameViewController.swift
@@ -162,7 +162,7 @@ public final class GameViewController: UIViewController {
   @objc private func gridCell33Tapped() { self.viewStore.send(.cellTapped(row: 2, column: 2)) }
 
   @objc private func quitButtonTapped() {
-    self.viewStore.send(.quitButtonTapped)
+    _ = self.navigationController?.popViewController(animated: true)
   }
 
   @objc private func playAgainButtonTapped() {

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -33,7 +33,6 @@ public struct LoginView: View {
     case emailChanged(String)
     case loginButtonTapped
     case passwordChanged(String)
-    case twoFactorDismissed
   }
 
   public init(store: StoreOf<Login>) {
@@ -66,30 +65,15 @@ public struct LoginView: View {
           )
         }
 
-        NavigationLink(
-          destination: IfLetStore(
-            self.store.scope(state: \.twoFactor, action: Login.Action.twoFactor)
-          ) {
-            TwoFactorView(store: $0)
-          },
-          isActive: viewStore.binding(
-            get: \.isTwoFactorActive,
-            send: {
-              // NB: SwiftUI will print errors to the console about "AttributeGraph: cycle detected"
-              //     if you disable a text field while it is focused. This hack will force all
-              //     fields to unfocus before we send the action to the view store.
-              // CF: https://stackoverflow.com/a/69653555
-              _ = UIApplication.shared.sendAction(
-                #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
-              )
-              return $0 ? .loginButtonTapped : .twoFactorDismissed
+        Button {
+          viewStore.send(.loginButtonTapped)
+        } label: {
+          HStack {
+            Text("Log in")
+            if viewStore.isActivityIndicatorVisible {
+              Spacer()
+              ProgressView()
             }
-          )
-        ) {
-          Text("Log in")
-          if viewStore.isActivityIndicatorVisible {
-            Spacer()
-            ProgressView()
           }
         }
         .disabled(viewStore.isLoginButtonDisabled)
@@ -98,6 +82,10 @@ public struct LoginView: View {
       .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
     }
     .navigationTitle("Login")
+    .navigationDestination(
+      store: self.store.scope(state: \.$twoFactor, action: Login.Action.twoFactor),
+      destination: TwoFactorView.init(store:)
+    )
   }
 }
 
@@ -106,12 +94,10 @@ extension Login.Action {
     switch action {
     case .alertDismissed:
       self = .alertDismissed
-    case .twoFactorDismissed:
-      self = .twoFactorDismissed
     case let .emailChanged(email):
       self = .emailChanged(email)
     case .loginButtonTapped:
-      self = .loginButtonTapped
+      self = .twoFactor(.present)
     case let .passwordChanged(password):
       self = .passwordChanged(password)
     }
@@ -120,7 +106,7 @@ extension Login.Action {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: Login.State(),

--- a/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/LoginUIKit/LoginViewController.swift
@@ -157,7 +157,7 @@ public class LoginViewController: UIViewController {
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: \.twoFactor, action: Login.Action.twoFactor)
+      .scope(state: \.twoFactor, action: { .twoFactor(.presented($0)) })
       .ifLet(
         then: { [weak self] twoFactorStore in
           self?.navigationController?.pushViewController(
@@ -167,7 +167,7 @@ public class LoginViewController: UIViewController {
         },
         else: { [weak self] in
           guard let self = self else { return }
-          self.navigationController?.popToViewController(self, animated: true)
+          _ = self.navigationController?.popToViewController(self, animated: true)
         }
       )
       .store(in: &self.cancellables)
@@ -202,11 +202,11 @@ extension Login.Action {
     case let .emailChanged(email):
       self = .emailChanged(email ?? "")
     case .loginButtonTapped:
-      self = .loginButtonTapped
+      self = .twoFactor(.present)
     case let .passwordChanged(password):
       self = .passwordChanged(password ?? "")
     case .twoFactorDismissed:
-      self = .twoFactorDismissed
+      self = .twoFactor(.dismiss)
     }
   }
 }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameCore/NewGameCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameCore/NewGameCore.swift
@@ -3,7 +3,7 @@ import GameCore
 
 public struct NewGame: ReducerProtocol {
   public struct State: Equatable {
-    public var game: Game.State?
+    @PresentationStateOf<Game> public var game
     public var oPlayerName = ""
     public var xPlayerName = ""
 
@@ -11,9 +11,7 @@ public struct NewGame: ReducerProtocol {
   }
 
   public enum Action: Equatable {
-    case game(Game.Action)
-    case gameDismissed
-    case letsPlayButtonTapped
+    case game(PresentationActionOf<Game>)
     case logoutButtonTapped
     case oPlayerNameChanged(String)
     case xPlayerNameChanged(String)
@@ -24,22 +22,14 @@ public struct NewGame: ReducerProtocol {
   public var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
-      case .game(.quitButtonTapped):
-        state.game = nil
-        return .none
-
-      case .gameDismissed:
-        state.game = nil
-        return .none
-
-      case .game:
-        return .none
-
-      case .letsPlayButtonTapped:
+      case .game(.present):
         state.game = Game.State(
           oPlayerName: state.oPlayerName,
           xPlayerName: state.xPlayerName
         )
+        return .none
+
+      case .game:
         return .none
 
       case .logoutButtonTapped:
@@ -54,7 +44,7 @@ public struct NewGame: ReducerProtocol {
         return .none
       }
     }
-    .ifLet(\.game, action: /NewGame.Action.game) {
+    .presentationDestination(\.$game, action: /Action.game) {
       Game()
     }
   }

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -22,7 +22,6 @@ public struct NewGameView: View {
   }
 
   enum ViewAction {
-    case gameDismissed
     case letsPlayButtonTapped
     case logoutButtonTapped
     case oPlayerNameChanged(String)
@@ -61,20 +60,16 @@ public struct NewGameView: View {
           Text("O Player Name")
         }
 
-        NavigationLink(
-          destination: IfLetStore(self.store.scope(state: \.game, action: NewGame.Action.game)) {
-            GameView(store: $0)
-          },
-          isActive: viewStore.binding(
-            get: \.isGameActive,
-            send: { $0 ? .letsPlayButtonTapped : .gameDismissed }
-          )
-        ) {
-          Text("Let's play!")
+        Button("Let's play!") {
+          viewStore.send(.letsPlayButtonTapped)
         }
         .disabled(viewStore.isLetsPlayButtonDisabled)
         .navigationTitle("New Game")
         .navigationBarItems(trailing: Button("Logout") { viewStore.send(.logoutButtonTapped) })
+        .navigationDestination(
+          store: self.store.scope(state: \.$game, action: NewGame.Action.game),
+          destination: GameView.init(store:)
+        )
       }
     }
   }
@@ -83,10 +78,8 @@ public struct NewGameView: View {
 extension NewGame.Action {
   init(action: NewGameView.ViewAction) {
     switch action {
-    case .gameDismissed:
-      self = .gameDismissed
     case .letsPlayButtonTapped:
-      self = .letsPlayButtonTapped
+      self = .game(.present)
     case .logoutButtonTapped:
       self = .logoutButtonTapped
     case let .oPlayerNameChanged(name):
@@ -99,7 +92,7 @@ extension NewGame.Action {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGame.State(),

--- a/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/NewGameUIKit/NewGameViewController.swift
@@ -123,7 +123,7 @@ public class NewGameViewController: UIViewController {
       .store(in: &self.cancellables)
 
     self.store
-      .scope(state: \.game, action: NewGame.Action.game)
+      .scope(state: \.game, action: { .game(.presented($0)) })
       .ifLet(
         then: { [weak self] gameStore in
           self?.navigationController?.pushViewController(
@@ -133,7 +133,7 @@ public class NewGameViewController: UIViewController {
         },
         else: { [weak self] in
           guard let self = self else { return }
-          self.navigationController?.popToViewController(self, animated: true)
+          _ = self.navigationController?.popToViewController(self, animated: true)
         }
       )
       .store(in: &self.cancellables)
@@ -168,9 +168,9 @@ extension NewGame.Action {
   init(action: NewGameViewController.ViewAction) {
     switch action {
     case .gameDismissed:
-      self = .gameDismissed
+      self = .game(.dismiss)
     case .letsPlayButtonTapped:
-      self = .letsPlayButtonTapped
+      self = .game(.present)
     case .logoutButtonTapped:
       self = .logoutButtonTapped
     case let .oPlayerNameChanged(name):

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -29,7 +29,7 @@ public struct TwoFactor: ReducerProtocol, Sendable {
 
   public init() {}
 
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .alertDismissed:
       state.alert = nil

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorCore/TwoFactorCore.swift
@@ -23,8 +23,6 @@ public struct TwoFactor: ReducerProtocol, Sendable {
     case twoFactorResponse(TaskResult<AuthenticationResponse>)
   }
 
-  public enum TearDownToken {}
-
   @Dependency(\.authenticationClient) var authenticationClient
 
   public init() {}
@@ -49,7 +47,6 @@ public struct TwoFactor: ReducerProtocol, Sendable {
           }
         )
       }
-      .cancellable(id: TearDownToken.self)
 
     case let .twoFactorResponse(.failure(error)):
       state.alert = AlertState(title: TextState(error.localizedDescription))

--- a/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactor.Action {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactor.State(token: "deadbeef"),

--- a/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/AppCoreTests/AppCoreTests.swift
@@ -29,7 +29,7 @@ final class AppCoreTests: XCTestCase {
         $0.isFormValid = true
       }
     }
-    await store.send(.login(.loginButtonTapped)) {
+    await store.send(.login(.twoFactor(.present))) {
       try (/TicTacToe.State.login).modify(&$0) {
         $0.isLoginRequestInFlight = true
       }
@@ -79,7 +79,7 @@ final class AppCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.login(.loginButtonTapped)) {
+    await store.send(.login(.twoFactor(.present))) {
       try (/TicTacToe.State.login).modify(&$0) {
         $0.isLoginRequestInFlight = true
       }
@@ -95,14 +95,14 @@ final class AppCoreTests: XCTestCase {
       }
     }
 
-    await store.send(.login(.twoFactor(.codeChanged("1234")))) {
+    await store.send(.login(.twoFactor(.presented(.codeChanged("1234"))))) {
       try (/TicTacToe.State.login).modify(&$0) {
         $0.twoFactor?.code = "1234"
         $0.twoFactor?.isFormValid = true
       }
     }
 
-    await store.send(.login(.twoFactor(.submitButtonTapped))) {
+    await store.send(.login(.twoFactor(.presented(.submitButtonTapped)))) {
       try (/TicTacToe.State.login).modify(&$0) {
         $0.twoFactor?.isTwoFactorRequestInFlight = true
       }
@@ -110,8 +110,10 @@ final class AppCoreTests: XCTestCase {
     await store.receive(
       .login(
         .twoFactor(
-          .twoFactorResponse(
-            .success(AuthenticationResponse(token: "deadbeef", twoFactorRequired: false))
+          .presented(
+            .twoFactorResponse(
+              .success(AuthenticationResponse(token: "deadbeef", twoFactorRequired: false))
+            )
           )
         )
       )

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameCoreTests/GameCoreTests.swift
@@ -12,7 +12,7 @@ final class GameCoreTests: XCTestCase {
     reducer: Game()
   )
 
-  func testFlow_Winner_Quit() async {
+  func testFlow_Winner() async {
     await self.store.send(.cellTapped(row: 0, column: 0)) {
       $0.board[0][0] = .x
       $0.currentPlayer = .o
@@ -32,7 +32,6 @@ final class GameCoreTests: XCTestCase {
     await self.store.send(.cellTapped(row: 2, column: 0)) {
       $0.board[2][0] = .x
     }
-    await self.store.send(.quitButtonTapped)
   }
 
   func testFlow_Tie() async {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/GameSwiftUITests/GameSwiftUITests.swift
@@ -38,7 +38,6 @@ final class GameSwiftUITests: XCTestCase {
       $0.isPlayAgainButtonVisible = true
       $0.title = "Winner! Congrats Blob Sr.!"
     }
-    await self.store.send(.quitButtonTapped)
   }
 
   func testFlow_Tie() async {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginCoreTests/LoginCoreTests.swift
@@ -26,7 +26,7 @@ final class LoginCoreTests: XCTestCase {
       $0.password = "password"
       $0.isFormValid = true
     }
-    await store.send(.loginButtonTapped) {
+    await store.send(.twoFactor(.present)) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(
@@ -37,17 +37,19 @@ final class LoginCoreTests: XCTestCase {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactor.State(token: "deadbeefdeadbeef")
     }
-    await store.send(.twoFactor(.codeChanged("1234"))) {
+    await store.send(.twoFactor(.presented(.codeChanged("1234")))) {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    await store.send(.twoFactor(.submitButtonTapped)) {
+    await store.send(.twoFactor(.presented(.submitButtonTapped))) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
     await store.receive(
       .twoFactor(
-        .twoFactorResponse(
-          .success(AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false))
+        .presented(
+          .twoFactorResponse(
+            .success(AuthenticationResponse(token: "deadbeefdeadbeef", twoFactorRequired: false))
+          )
         )
       )
     ) {
@@ -76,7 +78,7 @@ final class LoginCoreTests: XCTestCase {
       $0.password = "password"
       $0.isFormValid = true
     }
-    await store.send(.loginButtonTapped) {
+    await store.send(.twoFactor(.present)) {
       $0.isLoginRequestInFlight = true
     }
     await store.receive(
@@ -87,14 +89,14 @@ final class LoginCoreTests: XCTestCase {
       $0.isLoginRequestInFlight = false
       $0.twoFactor = TwoFactor.State(token: "deadbeefdeadbeef")
     }
-    await store.send(.twoFactor(.codeChanged("1234"))) {
+    await store.send(.twoFactor(.presented(.codeChanged("1234")))) {
       $0.twoFactor?.code = "1234"
       $0.twoFactor?.isFormValid = true
     }
-    await store.send(.twoFactor(.submitButtonTapped)) {
+    await store.send(.twoFactor(.presented(.submitButtonTapped))) {
       $0.twoFactor?.isTwoFactorRequestInFlight = true
     }
-    await store.send(.twoFactorDismissed) {
+    await store.send(.twoFactor(.dismiss)) {
       $0.twoFactor = nil
     }
     await store.finish()

--- a/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/LoginSwiftUITests/LoginSwiftUITests.swift
@@ -70,9 +70,6 @@ final class LoginSwiftUITests: XCTestCase {
       $0.isFormDisabled = false
       $0.isTwoFactorActive = true
     }
-    await store.send(.twoFactorDismissed) {
-      $0.isTwoFactorActive = false
-    }
   }
 
   func testFlow_Failure() async {

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameCoreTests/NewGameCoreTests.swift
@@ -17,20 +17,20 @@ final class NewGameCoreTests: XCTestCase {
     await self.store.send(.xPlayerNameChanged("Blob Jr.")) {
       $0.xPlayerName = "Blob Jr."
     }
-    await self.store.send(.letsPlayButtonTapped) {
+    await self.store.send(.game(.present)) {
       $0.game = Game.State(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    await self.store.send(.game(.cellTapped(row: 0, column: 0))) {
+    await self.store.send(.game(.presented(.cellTapped(row: 0, column: 0)))) {
       $0.game!.board[0][0] = .x
       $0.game!.currentPlayer = .o
     }
-    await self.store.send(.game(.quitButtonTapped)) {
+    await self.store.send(.game(.dismiss)) {
       $0.game = nil
     }
-    await self.store.send(.letsPlayButtonTapped) {
+    await self.store.send(.game(.present)) {
       $0.game = Game.State(oPlayerName: "Blob Sr.", xPlayerName: "Blob Jr.")
     }
-    await self.store.send(.gameDismissed) {
+    await self.store.send(.game(.dismiss)) {
       $0.game = nil
     }
     await self.store.send(.logoutButtonTapped)

--- a/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
+++ b/Examples/TicTacToe/tic-tac-toe/Tests/NewGameSwiftUITests/NewGameSwiftUITests.swift
@@ -23,9 +23,5 @@ final class NewGameSwiftUITests: XCTestCase {
     await self.store.send(.letsPlayButtonTapped) {
       $0.isGameActive = true
     }
-    await self.store.send(.gameDismissed) {
-      $0.isGameActive = false
-    }
-    await self.store.send(.logoutButtonTapped)
   }
 }

--- a/Examples/Todos/Todos/Todo.swift
+++ b/Examples/Todos/Todos/Todo.swift
@@ -13,7 +13,7 @@ struct Todo: ReducerProtocol {
     case textFieldChanged(String)
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .checkBoxToggled:
       state.isComplete.toggle()

--- a/Examples/Todos/Todos/Todos.swift
+++ b/Examples/Todos/Todos/Todos.swift
@@ -1,12 +1,6 @@
 import ComposableArchitecture
 @preconcurrency import SwiftUI
 
-enum Filter: LocalizedStringKey, CaseIterable, Hashable {
-  case all = "All"
-  case active = "Active"
-  case completed = "Completed"
-}
-
 struct Todos: ReducerProtocol {
   struct State: Equatable {
     var editMode: EditMode = .inactive
@@ -31,6 +25,12 @@ struct Todos: ReducerProtocol {
     case move(IndexSet, Int)
     case sortCompletedTodos
     case todo(id: Todo.State.ID, action: Todo.Action)
+  }
+
+  enum Filter: LocalizedStringKey, CaseIterable, Hashable {
+    case all = "All"
+    case active = "Active"
+    case completed = "Completed"
   }
 
   @Dependency(\.mainQueue) var mainQueue
@@ -113,7 +113,7 @@ struct AppView: View {
 
   struct ViewState: Equatable {
     let editMode: EditMode
-    let filter: Filter
+    let filter: Todos.Filter
     let isClearCompletedButtonDisabled: Bool
 
     init(state: Todos.State) {
@@ -134,7 +134,7 @@ struct AppView: View {
           )
           .animation()
         ) {
-          ForEach(Filter.allCases, id: \.self) { filter in
+          ForEach(Todos.Filter.allCases, id: \.self) { filter in
             Text(filter.rawValue).tag(filter)
           }
         }

--- a/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/RecordingMemo.swift
@@ -32,7 +32,7 @@ struct RecordingMemo: ReducerProtocol {
   @Dependency(\.audioRecorder) var audioRecorder
   @Dependency(\.mainRunLoop) var mainRunLoop
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .audioRecorderDidFinish(.success(true)):
       return .task { [state] in .delegate(.didFinish(.success(state))) }

--- a/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
+++ b/Examples/VoiceMemos/VoiceMemos/VoiceMemo.swift
@@ -39,7 +39,7 @@ struct VoiceMemo: ReducerProtocol {
   @Dependency(\.mainRunLoop) var mainRunLoop
   private enum PlayID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .audioPlayerClient:
       state.mode = .notPlaying

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/Sources/ComposableArchitecture/Dependencies/Dismiss.swift
+++ b/Sources/ComposableArchitecture/Dependencies/Dismiss.swift
@@ -1,0 +1,46 @@
+extension DependencyValues {
+  public var dismiss: DismissEffect {
+    get { self[DismissKey.self] }
+    set { self[DismissKey.self] = newValue }
+  }
+
+  private enum DismissKey: DependencyKey {
+    static let liveValue = DismissEffect()
+    static var testValue = DismissEffect()
+  }
+}
+
+public struct DismissEffect: Sendable {
+  private var dismiss: (@Sendable () async -> Void)?
+
+  public func callAsFunction(
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) async {
+    guard let dismiss = self.dismiss
+    else {
+      runtimeWarn(
+        """
+        A reducer requested dismissal at "\(fileID):\(line)", but couldn't be dismissed. …
+
+        This is generally considered an application logic error, and can happen when a reducer \
+        assumes it runs in a presentation destination. If a reducer can run at both the root level \
+        of an application, as well as in a presentation destination, use \
+        @Dependency(\\.isPresented) to determine if the reducer is being presented before calling \
+        @Dependency(\\.dismiss).
+        """,
+        file: file,
+        line: line
+      )
+      return
+    }
+    await dismiss()
+  }
+}
+
+extension DismissEffect {
+  public init(_ dismiss: @escaping @Sendable () async -> Void) {
+    self.dismiss = dismiss
+  }
+}

--- a/Sources/ComposableArchitecture/Dependencies/IsPresented.swift
+++ b/Sources/ComposableArchitecture/Dependencies/IsPresented.swift
@@ -1,0 +1,5 @@
+extension DependencyValues {
+  public var isPresented: Bool {
+    self.navigationID.current != nil
+  }
+}

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Bindings.md
@@ -54,7 +54,7 @@ struct Settings: ReducerProtocol {
   
   func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectTask<Action> {
     switch action {
     case let .isHapticFeedbackEnabledChanged(isEnabled):
       state.isHapticFeedbackEnabled = isEnabled
@@ -146,7 +146,7 @@ struct Settings: ReducerProtocol {
 
   func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectTask<Action> {
     switch action {
     case let digestChanged(digest):
       state.digest = digest

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/DependencyManagement.md
@@ -48,7 +48,7 @@ struct Todos: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .addButtonTapped:
       state.todos.append(Todo(id: UUID())

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/GettingStarted.md
@@ -42,7 +42,7 @@ your domain:
     user actions, notifications, event sources and more.
 * **Reducer**: A function that describes how to evolve the current state of the app to the next
     state given an action. The reducer is also responsible for returning any effects that should be
-    run, such as API requests, which can be done by returning an `Effect` value.
+    run, such as API requests, which can be done by returning an `EffectTask` value.
 * **Store**: The runtime that actually drives your feature. You send all user actions to the store
     so that the store can run the reducer and effects, and you can observe state changes in the
     store so that you can update UI.
@@ -94,8 +94,8 @@ struct Feature: ReducerProtocol {
 }
 ```
 
-And then we implement the ``ReducerProtocol/reduce(into:action:)-4nzr2`` method which is responsible 
-for handling the actual logic and behavior for the feature. It describes how to change the current 
+And then we implement the ``ReducerProtocol/reduce(into:action:)-8yinq`` method which is responsible 
+for handling the actual logic and  behavior for the feature. It describes how to change the current 
 state to the next state, and describes what effects need to be executed. Some actions don't need to 
 execute effects, and they can return `.none` to represent that:
 
@@ -104,7 +104,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { … }
   enum Action: Equatable { … }
   
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
       case .factAlertDismissed:
         state.numberFactAlert = nil

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/MigratingToTheReducerProtocol.md
@@ -64,7 +64,7 @@ You can convert this to the protocol style by:
 `Action`.
 1. Move the fields on the environment to be fields on this new reducer type, and delete the 
 environment type.
-1. Move the reducer's closure implementation to the ``ReducerProtocol/reduce(into:action:)-4nzr2`` 
+1. Move the reducer's closure implementation to the ``ReducerProtocol/reduce(into:action:)-8yinq`` 
 method.
 
 Performing these 4 steps on the feature produces the following:
@@ -81,7 +81,7 @@ struct Feature: ReducerProtocol {
 
   let date: () -> Date
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     // ...
     }
@@ -187,7 +187,7 @@ struct TabA: ReducerProtocol {
   enum Action {
     // ...
   }
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     // ...
   }
 }

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Performance.md
@@ -215,7 +215,7 @@ at each layer a reducer can intercept and reinterpret the action.
 
 It is far better to share logic via simple methods on your ``ReducerProtocol`` conformance.
 The helper methods can take `inout State` as an argument if it needs to make mutations, and it
-can return an `Effect<Action, Never>`. This allows you to share logic without incurring the cost
+can return an `EffectTask<Action>`. This allows you to share logic without incurring the cost
 of sending needless actions.
 
 For example, suppose that there are 3 UI components in your feature such that when any is changed
@@ -232,19 +232,19 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case .toggleChanged:
       state.isEnabled.toggle()
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case let .textFieldChanged(text):
       state.description = = text
-      return Effect(value: .sharedComputation)
+      return EffectTask(value: .sharedComputation)
 
     case .sharedComputation:
       // Some shared work to compute something.
@@ -301,7 +301,7 @@ and executing synchronous effects.
 
 Instead, we recommend sharing logic with methods defined in your feature's reducer. The method has
 full access to all dependencies, it can take an `inout State` if it needs to make mutations to 
-state, and it can return an `Effect<Action, Never>` if it needs to execute effects.
+state, and it can return an `EffectTask<Action>` if it needs to execute effects.
 
 The above example can be refactored like so:
 
@@ -314,7 +314,7 @@ struct Feature: ReducerProtocol {
     // ...
   }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       state.count += 1
@@ -330,7 +330,7 @@ struct Feature: ReducerProtocol {
     }
   }
 
-  func sharedComputation(state: inout State) -> Effect<Action, Never> {
+  func sharedComputation(state: inout State) -> EffectTask<Action> {
     // Some shared work to compute something.
     return .run { send in
       // A shared effect to compute something
@@ -381,8 +381,8 @@ store.send(.textFieldChanged("Hello") {
 
 Reducers are run on the main thread and so they are not appropriate for performing intense CPU
 work. If you need to perform lots of CPU-bound work, then it is more appropriate to use an
-``Effect``, which will operate in the cooperative thread pool, and then send actions back into the
-system. You should also make sure to perform your CPU intensive work in a cooperative manner by
+``EffectTask``, which will operate in the cooperative thread pool, and then send actions back into 
+the system. You should also make sure to perform your CPU intensive work in a cooperative manner by
 periodically suspending with `Task.yield()` so that you do not block a thread in the cooperative
 pool for too long.
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/SwiftConcurrency.md
@@ -7,11 +7,11 @@ and functions that are not thread-safe in concurrent contexts. Many of these war
 for the time being, but in Swift 6 most (if not all) of these warnings will become errors, and so
 you will need to know how to prove to the compiler that your types are safe to use concurrently.
 
-There are 3 primary ways to create an ``Effect`` in the library:
+There are 3 primary ways to create an ``EffectTask`` in the library:
 
-  * ``Effect/task(priority:operation:catch:file:fileID:line:)``
-  * ``Effect/run(priority:operation:catch:file:fileID:line:)``
-  * ``Effect/fireAndForget(priority:_:)``
+  * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+  * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+  * ``EffectPublisher/fireAndForget(priority:_:)``
 
 Each of these constructors takes a `@Sendable`, asynchronous closure, which restricts the types of
 closures you can use for your effects. In particular, the closure can only capture `Sendable`
@@ -32,7 +32,7 @@ struct Feature: ReducerProtocol {
   struct State { … }
   enum Action { … }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .buttonTapped:
       return .task {

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -96,7 +96,7 @@ await store.send(.incrementButtonTapped) {
 ```
 
 > The ``TestStore/send(_:_:file:line:)-6s1gq`` method is `async` for technical reasons that we do
-not have to worry about right now.
+> not have to worry about right now.
 
 If your mutation is incorrect, meaning you perform a mutation that is different from what happened
 in the ``Reducer``, then you will get a test failure with a nicely formatted message showing exactly

--- a/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Articles/Testing.md
@@ -24,7 +24,7 @@ struct Feature: ReducerProtocol {
   struct State: Equatable { var count = 0 }
   enum Action { case incrementButtonTapped, decrementButtonTapped }
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .incrementButtonTapped:
       state.count += 1
@@ -175,8 +175,8 @@ store.send(.incrementButtonTapped) {
 
 Testing state mutations as shown in the previous section is powerful, but is only half the story
 when it comes to testing features built in the Composable Architecture. The second responsibility of
-``Reducer``s, after mutating state from an action, is to return an ``Effect`` that encapsulates a
-unit of work that runs in the outside world and feeds data back into the system.
+``Reducer``s, after mutating state from an action, is to return an ``EffectTask`` that encapsulates 
+a unit of work that runs in the outside world and feeds data back into the system.
 
 Effects form a major part of a feature's logic. They can perform network requests to external
 services, load and save data to disk, start and stop timers, interact with Apple frameworks (Core
@@ -184,8 +184,8 @@ Location, Core Motion, Speech Recognition, etc.), and more.
 
 As a simple example, suppose we have a feature with a button such that when you tap it, it starts
 a timer that counts up until you reach 5, and then stops. This can be accomplished using the
-``Effect/run(priority:operation:catch:file:fileID:line:)`` helper, which provides you with an
-asynchronous context to operate in and can send multiple actions back into the system:
+``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` helper, which provides you with 
+an asynchronous context to operate in and can send multiple actions back into the system:
 
 ```swift
 struct Feature: ReducerProtocol {
@@ -193,7 +193,7 @@ struct Feature: ReducerProtocol {
   enum Action { case startTimerButtonTapped, timerTick }
   enum TimerID {}
 
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .startTimerButtonTapped:
       state.count = 0
@@ -251,7 +251,7 @@ supposed to be running, or perhaps the data it feeds into the system later is wr
 requires all effects to finish.
 
 To get this test passing we need to assert on the actions that are sent back into the system
-by the effect. We do this by using the ``TestStore/receive(_:timeout:_:file:line:)`` method,
+by the effect. We do this by using the ``TestStore/receive(_:timeout:_:file:line:)-8yd62`` method,
 which allows you to assert which action you expect to receive from an effect, as well as how the
 state changes after receiving that effect:
 
@@ -269,7 +269,7 @@ going to be received, but after waiting around for a small amount of time no act
 ```
 
 This is because our timer is on a 1 second interval, and by default
-``TestStore/receive(_:timeout:_:file:line:)`` only waits for a fraction of a second. This is
+``TestStore/receive(_:timeout:_:file:line:)-8yd62`` only waits for a fraction of a second. This is
 because typically you should not be performing real time-based asynchrony in effects, and instead
 using a controlled entity, such as a scheduler or clock, that can be sped up in tests. We will
 demonstrate this in a moment, so for now let's increase the timeout:
@@ -369,7 +369,7 @@ store.dependencies.mainQueue = .immediate
 ```
 
 With that small change we can drop the `timeout` arguments from the
-``TestStore/receive(_:timeout:_:file:line:)`` invocations:
+``TestStore/receive(_:timeout:_:file:line:)-8yd62`` invocations:
 
 ```swift
 await store.receive(.timerTick) {

--- a/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md
@@ -60,7 +60,7 @@ day-to-day when building applications, such as:
 ### State management
 
 - ``ReducerProtocol``
-- ``Effect``
+- ``EffectPublisher``
 - ``Store``
 - ``ViewStore``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/EffectDeprecations.md
@@ -10,41 +10,36 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Creating an effect
 
-- ``Effect/task(priority:operation:)``
+- ``EffectPublisher/task(priority:operation:)``
 
 ### Cancellation
 
-- ``Effect/cancel(ids:)-9tnmm``
-
-### Composition
-
-- ``Effect/concatenate(_:)-3awnj``
-- ``Effect/concatenate(_:)-8x6rz``
+- ``EffectPublisher/cancel(ids:)-8q1hl``
 
 ### Testing
 
-- ``Effect/failing(_:)``
-- ``Effect/unimplemented(_:)``
+- ``EffectPublisher/failing(_:)``
+- ``EffectPublisher/unimplemented(_:)``
 
 ### Combine integration
 
-- ``Effect/Output``
-- ``Effect/init(_:)``
-- ``Effect/init(value:)``
-- ``Effect/init(error:)``
-- ``Effect/upstream``
-- ``Effect/catching(_:)``
-- ``Effect/debounce(id:for:scheduler:options:)-8x633``
-- ``Effect/debounce(id:for:scheduler:options:)-76yye``
-- ``Effect/deferred(for:scheduler:options:)``
-- ``Effect/fireAndForget(_:)``
-- ``Effect/future(_:)``
-- ``Effect/receive(subscriber:)``
-- ``Effect/result(_:)``
-- ``Effect/run(_:)``
-- ``Effect/throttle(id:for:scheduler:latest:)-9kwd5``
-- ``Effect/throttle(id:for:scheduler:latest:)-5jfpx``
-- ``Effect/timer(id:every:tolerance:on:options:)-4exe6``
-- ``Effect/timer(id:every:tolerance:on:options:)-7po0d``
-- ``Effect/Subscriber``
+- ``EffectPublisher/Output``
+- ``EffectPublisher/init(_:)``
+- ``EffectPublisher/init(value:)``
+- ``EffectPublisher/init(error:)``
+- ``EffectPublisher/upstream``
+- ``EffectPublisher/catching(_:)``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-1xdnj``
+- ``EffectPublisher/debounce(id:for:scheduler:options:)-1oaak``
+- ``EffectPublisher/deferred(for:scheduler:options:)``
+- ``EffectPublisher/fireAndForget(_:)``
+- ``EffectPublisher/future(_:)``
+- ``EffectPublisher/receive(subscriber:)``
+- ``EffectPublisher/result(_:)``
+- ``EffectPublisher/run(_:)``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-3gibe``
+- ``EffectPublisher/throttle(id:for:scheduler:latest:)-85y01``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-6yv2m``
+- ``EffectPublisher/timer(id:every:tolerance:on:options:)-8t3is``
+- ``EffectPublisher/Subscriber``
 <!--DocC: Can't currently document `Publisher` extensions. -->

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/TestStoreDeprecations.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/TestStoreDeprecations.md
@@ -18,12 +18,12 @@ Avoid using deprecated APIs in your app. Select a method to see the replacement 
 
 ### Testing reducers
 
-- ``TestStore/send(_:_:file:line:)-2anca``
-- ``TestStore/receive(_:timeout:_:file:line:)``
+- ``TestStore/send(_:_:file:line:)-4i91s``
+- ``TestStore/receive(_:timeout:_:file:line:)-8huvm``
 - ``TestStore/receive(_:_:file:line:)``
-- ``TestStore/finish(timeout:file:line:)``
-- ``TestStore/assert(_:file:line:)-4n483``
-- ``TestStore/assert(_:file:line:)-5k4u0``
+- ``TestStore/finish(timeout:file:line:)-43l4y``
+- ``TestStore/assert(_:file:line:)-707lb``
+- ``TestStore/assert(_:file:line:)-4gff7``
 - ``TestStore/LocalState``
 - ``TestStore/LocalAction``
 - ``TestStore/Step``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/Effect.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect``
+# ``ComposableArchitecture/EffectPublisher``
 
 ## Topics
 
@@ -12,16 +12,16 @@
 
 ### Cancellation
 
-- ``cancellable(id:cancelInFlight:)-499iv``
-- ``cancel(id:)-7vmd9``
-- ``cancel(ids:)-8gan2``
-- ``withTaskCancellation(id:cancelInFlight:operation:)-88kxz``
+- ``cancellable(id:cancelInFlight:)-29q60``
+- ``cancel(id:)-6hzsl``
+- ``cancel(ids:)-1cqqx``
+- ``withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
 
 ### Composition
 
-- ``map(_:)-28ghh``
-- ``merge(_:)-3al9f``
-- ``merge(_:)-4n451``
+- ``map(_:)-yn70``
+- ``merge(_:)-45guh``
+- ``merge(_:)-3d54p``
 
 ### Concurrency
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancel.md
@@ -1,7 +1,7 @@
-# ``ComposableArchitecture/Effect/cancel(id:)-7vmd9``
+# ``ComposableArchitecture/EffectPublisher/cancel(id:)-6hzsl``
 
 ## Topics
 
 ### Overloads
 
-- ``cancel(id:)-iun1``
+- ``cancel(id:)-1c1dw``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancelIds.md
@@ -1,7 +1,7 @@
-# ``ComposableArchitecture/Effect/cancel(ids:)-8gan2``
+# ``ComposableArchitecture/EffectPublisher/cancel(ids:)-8gan2``
 
 ## Topics
 
 ### Overloads
 
-- ``cancel(ids:)-dmwy``
+- ``cancel(ids:)-1cqqx``

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancellable.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectCancellable.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/cancellable(id:cancelInFlight:)-499iv``
+# ``ComposableArchitecture/EffectPublisher/cancellable(id:cancelInFlight:)-499iv``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectRun.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/EffectRun.md
@@ -1,4 +1,4 @@
-# ``ComposableArchitecture/Effect/run(priority:operation:catch:file:fileID:line:)``
+# ``ComposableArchitecture/EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
 
 ## Topics
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md
@@ -4,10 +4,10 @@
 
 ### Implementing a reducer
 
-- ``reduce(into:action:)-4nzr2``
+- ``reduce(into:action:)-8yinq``
 - ``State``
 - ``Action``
-- ``Effect``
+- ``EffectPublisher``
 
 ### Reducer composition
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/TestStore.md
@@ -14,13 +14,13 @@
 ### Testing a reducer
 
 - ``send(_:_:file:line:)-6s1gq``
-- ``receive(_:timeout:_:file:line:)``
-- ``finish(timeout:file:line:)``
+- ``receive(_:timeout:_:file:line:)-8yd62``
+- ``finish(timeout:file:line:)-7pmv3``
 - ``TestStoreTask``
 
 ### Accessing state
 
-While the most common way of interacting with a test store's state is via its ``send(_:_:file:line:)-6s1gq`` and ``receive(_:timeout:_:file:line:)`` methods, you may also access it directly throughout a test.
+While the most common way of interacting with a test store's state is via its ``send(_:_:file:line:)-6s1gq`` and ``receive(_:timeout:_:file:line:)-8yd62`` methods, you may also access it directly throughout a test.
 
 - ``state``
 

--- a/Sources/ComposableArchitecture/Documentation.docc/Extensions/WithTaskCancellation.md
+++ b/Sources/ComposableArchitecture/Documentation.docc/Extensions/WithTaskCancellation.md
@@ -1,7 +1,7 @@
-# ``ComposableArchitecture/withTaskCancellation(id:cancelInFlight:operation:)-88kxz``
+# ``ComposableArchitecture/withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
 
 ## Topics
 
 ### Overloads
 
-- ``withTaskCancellation(id:cancelInFlight:operation:)-4dtr6``
+- ``withTaskCancellation(id:cancelInFlight:operation:)-88kxz``

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -16,23 +16,23 @@ import XCTestDynamicOverlay
 /// * If using Swift's native structured concurrency tools then there are 3 main ways to create an
 /// effect, depending on if you want to emit one single action back into the system, or any number
 /// of actions, or just execute some work without emitting any actions:
-///   * ``Effect/task(priority:operation:catch:file:fileID:line:)``
-///   * ``Effect/run(priority:operation:catch:file:fileID:line:)``
-///   * ``Effect/fireAndForget(priority:_:)``
+///   * ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``
+///   * ``EffectPublisher/fireAndForget(priority:_:)``
 /// * If using Combine in your application, in particular for the dependencies of your feature
 /// then you can create effects by making use of any of Combine's operators, and then erasing the
-/// publisher type to ``Effect`` with either `eraseToEffect` or `catchToEffect`. Note that the
-/// Combine interface to ``Effect`` is considered soft deprecated, and you should eventually port
-/// to Swift's native concurrency tools.
+/// publisher type to ``EffectPublisher`` with either `eraseToEffect` or `catchToEffect`. Note that
+/// the Combine interface to ``EffectPublisher`` is considered soft deprecated, and you should
+/// eventually port to Swift's native concurrency tools.
 ///
 /// > Important: ``Store`` is not thread safe, and so all effects must receive values on the same
 /// thread. This is typically the main thread,  **and** if the store is being used to drive UI then
 /// it must receive values on the main thread.
 /// >
-/// > This is only an issue if using the Combine interface of ``Effect`` as mentioned above. If you
-/// you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget` functions
-/// on ``Effect``, then threading is automatically handled for you.
-public struct Effect<Action, Failure: Error> {
+/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
+/// above. If  you are using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
+/// functions on ``EffectTask``, then threading is automatically handled for you.
+public struct EffectPublisher<Action, Failure: Error> {
   @usableFromInline
   enum Operation {
     case none
@@ -51,7 +51,7 @@ public struct Effect<Action, Failure: Error> {
 
 // MARK: - Creating Effects
 
-extension Effect {
+extension EffectPublisher {
   /// An effect that does nothing and completes immediately. Useful for situations where you must
   /// return an effect, but you don't need to do anything.
   @inlinable
@@ -60,11 +60,27 @@ extension Effect {
   }
 }
 
-extension Effect where Failure == Never {
+/// A convenience type alias for referring to an effect that can never fail, like the kind of
+/// ``EffectPublisher`` returned by a reducer after processing an action.
+///
+/// Instead of specifying `Never` as `Failure`:
+///
+/// ```swift
+/// func reduce(into state: inout State, action: Action) -> EffectPublisher<Action, Never> { … }
+/// ```
+///
+/// You can specify a single generic:
+///
+/// ```swift
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action>  { … }
+/// ```
+public typealias EffectTask<Action> = Effect<Action, Never>
+
+extension EffectPublisher where Failure == Never {
   /// Wraps an asynchronous unit of work in an effect.
   ///
   /// This function is useful for executing work in an asynchronous context and capturing the result
-  /// in an ``Effect`` so that the reducer, a non-asynchronous context, can process it.
+  /// in an ``EffectTask`` so that the reducer, a non-asynchronous context, can process it.
   ///
   /// For example, if your dependency exposes an `async` function, you can use
   /// ``task(priority:operation:catch:file:fileID:line:)`` to provide an asynchronous context for
@@ -79,7 +95,7 @@ extension Effect where Failure == Never {
   ///   }
   ///   @Dependency(\.numberFact) var numberFact
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///       case .factButtonTapped:
   ///         return .task { [number = state.number] in
@@ -136,12 +152,12 @@ extension Effect where Failure == Never {
                 customDump(error, to: &errorDump, indent: 4)
                 runtimeWarn(
                   """
-                  An "Effect.task" returned from "\(fileID):\(line)" threw an unhandled error. …
+                  An "EffectTask.task" returned from "\(fileID):\(line)" threw an unhandled error. …
 
                   \(errorDump)
 
                   All non-cancellation errors must be explicitly handled via the "catch" parameter \
-                  on "Effect.task", or via a "do" block.
+                  on "EffectTask.task", or via a "do" block.
                   """,
                   file: file,
                   line: line
@@ -218,12 +234,12 @@ extension Effect where Failure == Never {
                 customDump(error, to: &errorDump, indent: 4)
                 runtimeWarn(
                   """
-                  An "Effect.run" returned from "\(fileID):\(line)" threw an unhandled error. …
+                  An "EffectTask.run" returned from "\(fileID):\(line)" threw an unhandled error. …
 
                   \(errorDump)
 
                   All non-cancellation errors must be explicitly handled via the "catch" parameter \
-                  on "Effect.run", or via a "do" block.
+                  on "EffectTask.run", or via a "do" block.
                   """,
                   file: file,
                   line: line
@@ -269,7 +285,7 @@ extension Effect where Failure == Never {
 }
 
 /// A type that can send actions back into the system when used from
-/// ``Effect/run(priority:operation:catch:file:fileID:line:)``.
+/// ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)``.
 ///
 /// This type implements [`callAsFunction`][callAsFunction] so that you invoke it as a function
 /// rather than calling methods on it:
@@ -291,7 +307,7 @@ extension Effect where Failure == Never {
 /// defer { send(.finished, animation: .default) }
 /// ```
 ///
-/// See ``Effect/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
+/// See ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` for more information on how to
 /// use this value to construct effects that can emit any number of times in an asynchronous
 /// context.
 ///
@@ -327,7 +343,7 @@ public struct Send<Action> {
 
 // MARK: - Composing Effects
 
-extension Effect {
+extension EffectPublisher {
   /// Merges a variadic list of effects together into a single effect, which runs the effects at the
   /// same time.
   ///
@@ -441,7 +457,7 @@ extension Effect {
   /// - Returns: A publisher that uses the provided closure to map elements from the upstream effect
   ///   to new elements that it then publishes.
   @inlinable
-  public func map<T>(_ transform: @escaping (Action) -> T) -> Effect<T, Failure> {
+  public func map<T>(_ transform: @escaping (Action) -> T) -> EffectPublisher<T, Failure> {
     switch self.operation {
     case .none:
       return .none
@@ -469,7 +485,7 @@ extension Effect {
 
 // MARK: - Testing Effects
 
-extension Effect {
+extension EffectPublisher {
   /// An effect that causes a test to fail if it runs.
   ///
   /// > Important: This Combine-based interface has been soft-deprecated in favor of Swift
@@ -516,7 +532,7 @@ extension Effect {
   ///
   /// ```swift
   /// struct CounterEnvironment {
-  ///   let playAlertSound: () -> Effect<Never, Never>
+  ///   let playAlertSound: () -> EffectPublisher<Never, Never>
   /// }
   /// ```
   ///
@@ -591,3 +607,61 @@ extension Effect {
     }
   }
 }
+
+@available(
+  iOS,
+  deprecated: 9999.0,
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model failable streams of values.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  macOS,
+  deprecated: 9999.0,
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model failable streams of values.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  tvOS,
+  deprecated: 9999.0,
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model failable streams of values.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+@available(
+  watchOS,
+  deprecated: 9999.0,
+  message:
+    """
+    'Effect' has been deprecated in favor of 'EffectTask' when `Failure == Never`, or
+    `EffectPublisher<Output, Failure>` in general.
+    
+    You are encouraged to use `EffectTask<Action>` to model the ouput of your reducers, and to Swift
+    concurrency to model failable streams of values.
+
+    See the migration roadmap for more information: https://github.com/pointfreeco/swift-composable-architecture/discussions/1477
+    """
+)
+public typealias Effect = EffectPublisher

--- a/Sources/ComposableArchitecture/Effects/Animation.swift
+++ b/Sources/ComposableArchitecture/Effects/Animation.swift
@@ -1,7 +1,7 @@
 import Combine
 import SwiftUI
 
-extension Effect {
+extension EffectPublisher {
   /// Wraps the emission of each element with SwiftUI's `withAnimation`.
   ///
   /// ```swift

--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -1,12 +1,12 @@
 import Combine
 import Foundation
 
-extension Effect {
+extension EffectPublisher {
   /// Turns an effect into one that is capable of being canceled.
   ///
   /// To turn an effect into a cancellable one you must provide an identifier, which is used in
-  /// ``Effect/cancel(id:)-iun1`` to identify which in-flight effect should be canceled. Any
-  /// hashable value can be used for the identifier, such as a string, but you can add a bit of
+  /// ``EffectPublisher/cancel(id:)-6hzsl`` to identify which in-flight effect should be canceled.
+  /// Any hashable value can be used for the identifier, such as a string, but you can add a bit of
   /// protection against typos by defining a new type for the identifier:
   ///
   /// ```swift
@@ -93,8 +93,8 @@ extension Effect {
 
   /// Turns an effect into one that is capable of being canceled.
   ///
-  /// A convenience for calling ``Effect/cancellable(id:cancelInFlight:)-17skv`` with a static type
-  /// as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancellable(id:cancelInFlight:)-29q60`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.
@@ -120,8 +120,8 @@ extension Effect {
 
   /// An effect that will cancel any currently in-flight effect with the given identifier.
   ///
-  /// A convenience for calling ``Effect/cancel(id:)-iun1`` with a static type as the effect's
-  /// unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancel(id:)-6hzsl`` with a static type as the
+  /// effect's unique identifier.
   ///
   /// - Parameter id: A unique type identifying the effect.
   /// - Returns: A new effect that will cancel any currently in-flight effect with the given
@@ -136,19 +136,19 @@ extension Effect {
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel(ids: [AnyHashable]) -> Self {
-    .merge(ids.map(Effect.cancel(id:)))
+    .merge(ids.map(EffectPublisher.cancel(id:)))
   }
 
   /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
   ///
-  /// A convenience for calling ``Effect/cancel(ids:)-dmwy`` with a static type as the effect's
-  /// unique identifier.
+  /// A convenience for calling ``EffectPublisher/cancel(ids:)-1cqqx`` with a static type as the
+  /// effect's unique identifier.
   ///
   /// - Parameter ids: An array of unique types identifying the effects.
   /// - Returns: A new effect that will cancel any currently in-flight effects with the given
   ///   identifiers.
   public static func cancel(ids: [Any.Type]) -> Self {
-    .merge(ids.map(Effect.cancel(id:)))
+    .merge(ids.map(EffectPublisher.cancel(id:)))
   }
 }
 

--- a/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
+++ b/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift
@@ -264,7 +264,7 @@ extension Task where Success == Never, Failure == Never {
 /// ```swift
 /// @Dependency(\.analytics) var analytics
 ///
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .buttonTapped:
 ///     return .fireAndForget { try await self.analytics.track("Button Tapped") }

--- a/Sources/ComposableArchitecture/Effects/Publisher.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher.swift
@@ -4,7 +4,7 @@ import Combine
 @available(macOS, deprecated: 9999.0)
 @available(tvOS, deprecated: 9999.0)
 @available(watchOS, deprecated: 9999.0)
-extension Effect: Publisher {
+extension EffectPublisher: Publisher {
   public typealias Output = Action
 
   public func receive<S: Combine.Subscriber>(
@@ -34,13 +34,14 @@ extension Effect: Publisher {
   }
 }
 
-extension Effect {
+extension EffectPublisher {
   /// Initializes an effect that wraps a publisher.
   ///
   /// > Important: This Combine interface has been soft-deprecated in favor of Swift concurrency.
   /// > Prefer performing asynchronous work directly in
-  /// > ``Effect/run(priority:operation:catch:file:fileID:line:)`` by adopting a non-Combine
-  /// > interface, or by iterating over the publisher's asynchronous sequence of `values`:
+  /// > ``EffectPublisher/run(priority:operation:catch:file:fileID:line:)`` by adopting a
+  /// > non-Combine interface, or by iterating over the publisher's asynchronous sequence of
+  /// > `values`:
   /// >
   /// > ```swift
   /// > return .run { send in
@@ -52,19 +53,20 @@ extension Effect {
   ///
   /// - Parameter publisher: A publisher.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
     self.operation = .publisher(publisher.eraseToAnyPublisher())
@@ -73,10 +75,10 @@ extension Effect {
   /// Initializes an effect that immediately emits the value passed in.
   ///
   /// - Parameter value: The value that is immediately emitted by the effect.
-  @available(iOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Wrap the value in 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Wrap the value in 'EffectTask.task', instead.")
   public init(value: Action) {
     self.init(Just(value).setFailureType(to: Failure.self))
   }
@@ -86,19 +88,19 @@ extension Effect {
   /// - Parameter error: The error that is immediately emitted by the effect.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   public init(error: Failure) {
     // NB: Ideally we'd return a `Fail` publisher here, but due to a bug in iOS 13 that publisher
@@ -115,12 +117,12 @@ extension Effect {
   /// Creates an effect that can supply a single value asynchronously in the future.
   ///
   /// This can be helpful for converting APIs that are callback-based into ones that deal with
-  /// ``Effect``s.
+  /// ``EffectPublisher``s.
   ///
   /// For example, to create an effect that delivers an integer after waiting a second:
   ///
   /// ```swift
-  /// Effect<Int, Never>.future { callback in
+  /// EffectPublisher<Int, Never>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///   }
@@ -131,7 +133,7 @@ extension Effect {
   /// discarded:
   ///
   /// ```swift
-  /// Effect<Int, Never>.future { callback in
+  /// EffectPublisher<Int, Never>.future { callback in
   ///   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
   ///     callback(.success(42))
   ///     callback(.success(1729)) // Will not be emitted by the effect
@@ -139,15 +141,15 @@ extension Effect {
   /// }
   /// ```
   ///
-  ///  If you need to deliver more than one value to the effect, you should use the ``Effect``
-  ///  initializer that accepts a ``Subscriber`` value.
+  ///  If you need to deliver more than one value to the effect, you should use the
+  ///  ``EffectPublisher`` initializer that accepts a ``Subscriber`` value.
   ///
   /// - Parameter attemptToFulfill: A closure that takes a `callback` as an argument which can be
   ///   used to feed it `Result<Output, Failure>` values.
-  @available(iOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
   public static func future(
     _ attemptToFulfill: @escaping (@escaping (Result<Action, Failure>) -> Void) -> Void
   ) -> Self {
@@ -165,7 +167,7 @@ extension Effect {
   /// For example, to load a user from some JSON on the disk, one can wrap that work in an effect:
   ///
   /// ```swift
-  /// Effect<User, Error>.result {
+  /// EffectPublisher<User, Error>.result {
   ///   let fileUrl = URL(
   ///     fileURLWithPath: NSSearchPathForDirectoriesInDomains(
   ///       .documentDirectory, .userDomainMask, true
@@ -184,10 +186,10 @@ extension Effect {
   ///
   /// - Parameter attemptToFulfill: A closure encapsulating some work to execute in the real world.
   /// - Returns: An effect.
-  @available(iOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
-  @available(watchOS, deprecated: 9999.0, message: "Use 'Effect.task', instead.")
+  @available(iOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(macOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(tvOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
+  @available(watchOS, deprecated: 9999.0, message: "Use 'EffectTask.task', instead.")
   public static func result(_ attemptToFulfill: @escaping () -> Result<Action, Failure>) -> Self {
     .future { $0(attemptToFulfill()) }
   }
@@ -196,15 +198,15 @@ extension Effect {
   /// a completion.
   ///
   /// This initializer is useful for bridging callback APIs, delegate APIs, and manager APIs to the
-  /// ``Effect`` type. One can wrap those APIs in an Effect so that its events are sent through the
-  /// effect, which allows the reducer to handle them.
+  /// ``EffectPublisher`` type. One can wrap those APIs in an Effect so that its events are sent
+  /// through the effect, which allows the reducer to handle them.
   ///
   /// For example, one can create an effect to ask for access to `MPMediaLibrary`. It can start by
   /// sending the current status immediately, and then if the current status is `notDetermined` it
   /// can request authorization, and once a status is received it can send that back to the effect:
   ///
   /// ```swift
-  /// Effect.run { subscriber in
+  /// EffectPublisher.run { subscriber in
   ///   subscriber.send(MPMediaLibrary.authorizationStatus())
   ///
   ///   guard MPMediaLibrary.authorizationStatus() == .notDetermined else {
@@ -224,16 +226,22 @@ extension Effect {
   /// ```
   ///
   /// - Parameter work: A closure that accepts a ``Subscriber`` value and returns a cancellable.
-  ///   When the ``Effect`` is completed, the cancellable will be used to clean up any resources
-  ///   created when the effect was started.
-  @available(iOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead.")
+  ///   When the ``EffectPublisher`` is completed, the cancellable will be used to clean up any
+  ///   resources created when the effect was started.
+  @available(
+    iOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use the async version of 'EffectTask.run', instead."
+  )
   @available(
     watchOS, deprecated: 9999.0, message: "Use the async version of 'Effect.run', instead."
   )
   public static func run(
-    _ work: @escaping (Effect.Subscriber) -> Cancellable
+    _ work: @escaping (EffectPublisher.Subscriber) -> Cancellable
   ) -> Self {
     let dependencies = DependencyValues._current
     return AnyPublisher.create { subscriber in
@@ -272,14 +280,14 @@ extension Effect {
   }
 }
 
-extension Effect where Failure == Error {
+extension EffectPublisher where Failure == Error {
   /// Initializes an effect that lazily executes some work in the real world and synchronously sends
   /// that data back into the store.
   ///
   /// For example, to load a user from some JSON on the disk, one can wrap that work in an effect:
   ///
   /// ```swift
-  /// Effect<User, Error>.catching {
+  /// EffectPublisher<User, Error>.catching {
   ///   let fileUrl = URL(
   ///     fileURLWithPath: NSSearchPathForDirectoriesInDomains(
   ///       .documentDirectory, .userDomainMask, true
@@ -296,19 +304,19 @@ extension Effect where Failure == Error {
   /// - Returns: An effect.
   @available(
     iOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Throw and catch errors directly in 'Effect.task' and 'Effect.run', instead."
+    message: "Throw and catch errors directly in 'EffectTask.task' and 'EffectTask.run', instead."
   )
   public static func catching(_ work: @escaping () throws -> Action) -> Self {
     .future { $0(Result { try work() }) }
@@ -316,7 +324,7 @@ extension Effect where Failure == Error {
 }
 
 extension Publisher {
-  /// Turns any publisher into an ``Effect``.
+  /// Turns any publisher into an ``EffectPublisher``.
   ///
   /// This can be useful for when you perform a chain of publisher transformations in a reducer, and
   /// you need to convert that publisher to an effect so that you can return it from the reducer:
@@ -330,28 +338,29 @@ extension Publisher {
   ///
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
-  public func eraseToEffect() -> Effect<Output, Failure> {
-    Effect(self)
+  public func eraseToEffect() -> EffectPublisher<Output, Failure> {
+    EffectPublisher(self)
   }
 
-  /// Turns any publisher into an ``Effect``.
+  /// Turns any publisher into an ``EffectPublisher``.
   ///
-  /// This is a convenience operator for writing ``Effect/eraseToEffect()`` followed by
-  /// ``Effect/map(_:)-28ghh`.
+  /// This is a convenience operator for writing ``EffectPublisher/eraseToEffect()`` followed by
+  /// ``EffectPublisher/map(_:)-28ghh`.
   ///
   /// ```swift
   /// case .buttonTapped:
@@ -364,29 +373,30 @@ extension Publisher {
   ///   - transform: A mapping function that converts `Output` to another type.
   /// - Returns: An effect that wraps `self` after mapping `Output` values.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public func eraseToEffect<T>(
     _ transform: @escaping (Output) -> T
-  ) -> Effect<T, Failure> {
+  ) -> EffectPublisher<T, Failure> {
     self.map(transform)
       .eraseToEffect()
   }
 
-  /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure in
-  /// a result.
+  /// Turns any publisher into an ``EffectTask`` that cannot fail by wrapping its output and failure
+  /// in a result.
   ///
   /// This can be useful when you are working with a failing API but want to deliver its data to an
   /// action that handles both success and failure.
@@ -400,29 +410,30 @@ extension Publisher {
   ///
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
-  public func catchToEffect() -> Effect<Result<Output, Failure>, Never> {
+  public func catchToEffect() -> EffectTask<Result<Output, Failure>> {
     self.catchToEffect { $0 }
   }
 
-  /// Turns any publisher into an ``Effect`` that cannot fail by wrapping its output and failure
+  /// Turns any publisher into an ``EffectTask`` that cannot fail by wrapping its output and failure
   /// into a result and then applying passed in function to it.
   ///
-  /// This is a convenience operator for writing ``Effect/eraseToEffect()`` followed by
-  /// ``Effect/map(_:)-28ghh`.
+  /// This is a convenience operator for writing ``EffectPublisher/eraseToEffect()`` followed by
+  /// ``EffectPublisher/map(_:)-28ghh`.
   ///
   /// ```swift
   /// case .buttonTapped:
@@ -434,23 +445,24 @@ extension Publisher {
   ///   - transform: A mapping function that converts `Result<Output,Failure>` to another type.
   /// - Returns: An effect that wraps `self`.
   @available(
-    iOS, deprecated: 9999.0, message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    iOS, deprecated: 9999.0,
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     macOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     tvOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   @available(
     watchOS, deprecated: 9999.0,
-    message: "Iterate over 'Publisher.values' in an 'Effect.run', instead."
+    message: "Iterate over 'Publisher.values' in an 'EffectTask.run', instead."
   )
   public func catchToEffect<T>(
     _ transform: @escaping (Result<Output, Failure>) -> T
-  ) -> Effect<T, Never> {
+  ) -> EffectTask<T> {
     let dependencies = DependencyValues._current
     let transform = { action in
       DependencyValues.$_current.withValue(dependencies) {
@@ -464,8 +476,8 @@ extension Publisher {
       .eraseToEffect()
   }
 
-  /// Turns any publisher into an ``Effect`` for any output and failure type by ignoring all output
-  /// and any failure.
+  /// Turns any publisher into an ``EffectPublisher`` for any output and failure type by ignoring
+  /// all output and any failure.
   ///
   /// This is useful for times you want to fire off an effect but don't want to feed any data back
   /// into the system. It can automatically promote an effect to your reducer's domain.
@@ -503,7 +515,7 @@ extension Publisher {
   public func fireAndForget<NewOutput, NewFailure>(
     outputType: NewOutput.Type = NewOutput.self,
     failureType: NewFailure.Type = NewFailure.self
-  ) -> Effect<NewOutput, NewFailure> {
+  ) -> EffectPublisher<NewOutput, NewFailure> {
     return
       self
       .flatMap { _ in Empty<NewOutput, Failure>() }

--- a/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Debouncing.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension Effect {
+extension EffectPublisher {
   /// Turns an effect into one that can be debounced.
   ///
   /// To turn an effect into a debounce-able one you must provide an identifier, which is used to
@@ -27,22 +27,22 @@ extension Effect {
   @available(
     iOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     macOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     tvOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   @available(
     watchOS,
     deprecated: 9999.0,
-    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'Effect.run', instead."
+    message: "Use 'withTaskCancellation(id: _, cancelInFlight: true)' in 'EffectTask.run', instead."
   )
   public func debounce<S: Scheduler>(
     id: AnyHashable,
@@ -69,8 +69,8 @@ extension Effect {
 
   /// Turns an effect into one that can be debounced.
   ///
-  /// A convenience for calling ``Effect/debounce(id:for:scheduler:options:)-76yye`` with a static
-  /// type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/debounce(id:for:scheduler:options:)-1xdnj`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Deferring.swift
@@ -1,6 +1,6 @@
 import Combine
 
-extension Effect {
+extension EffectPublisher {
   /// Returns an effect that will be executed after given `dueTime`.
   ///
   /// ```swift
@@ -15,11 +15,17 @@ extension Effect {
   ///   - scheduler: The scheduler you want to deliver the defer output to.
   ///   - options: Scheduler options that customize the effect's delivery of elements.
   /// - Returns: An effect that will be executed after `dueTime`
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.sleep' in 'EffectTask.run', instead."
   )
   public func deferred<S: Scheduler>(
     for dueTime: S.SchedulerTimeType.Stride,

--- a/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Throttling.swift
@@ -2,7 +2,7 @@ import Combine
 import Dispatch
 import Foundation
 
-extension Effect {
+extension EffectPublisher {
   /// Throttles an effect so that it only publishes one output per given interval.
   ///
   /// - Parameters:
@@ -67,8 +67,8 @@ extension Effect {
 
   /// Throttles an effect so that it only publishes one output per given interval.
   ///
-  /// A convenience for calling ``Effect/throttle(id:for:scheduler:latest:)-5jfpx`` with a static
-  /// type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/throttle(id:for:scheduler:latest:)-3gibe`` with a
+  /// static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: The effect's identifier.

--- a/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Publisher/Timer.swift
@@ -1,7 +1,7 @@
 import Combine
 import CombineSchedulers
 
-extension Effect where Failure == Never {
+extension EffectPublisher where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
   /// interval.
   ///
@@ -15,12 +15,12 @@ extension Effect where Failure == Never {
   /// we can see how effects emit. However, because `Timer.publish` takes a concrete `RunLoop` as
   /// its scheduler, we can't substitute in a `TestScheduler` during tests`.
   ///
-  /// That is why we provide `Effect.timer`. It allows you to create a timer that works with any
+  /// That is why we provide `EffectTask.timer`. It allows you to create a timer that works with any
   /// scheduler, not just a run loop, which means you can use a `DispatchQueue` or `RunLoop` when
   /// running your live app, but use a `TestScheduler` in tests.
   ///
   /// To start and stop a timer in your feature you can create the timer effect from an action
-  /// and then use the ``Effect/cancel(id:)-iun1`` effect to stop the timer:
+  /// and then use the ``EffectPublisher/cancel(id:)-6hzsl`` effect to stop the timer:
   ///
   /// ```swift
   /// struct Feature: ReducerProtocol {
@@ -29,10 +29,10 @@ extension Effect where Failure == Never {
   ///   @Dependency(\.mainQueue) var mainQueue
   ///   struct TimerID: Hashable {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .startButtonTapped:
-  ///       return Effect.timer(id: TimerID(), every: 1, on: self.mainQueue)
+  ///       return EffectTask.timer(id: TimerID(), every: 1, on: self.mainQueue)
   ///         .map { _ in .timerTicked }
   ///
   ///     case .stopButtonTapped:
@@ -89,11 +89,17 @@ extension Effect where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
   )
   public static func timer<S: Scheduler>(
     id: AnyHashable,
@@ -112,8 +118,8 @@ extension Effect where Failure == Never {
   /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
   /// interval.
   ///
-  /// A convenience for calling ``Effect/timer(id:every:tolerance:on:options:)-4exe6`` with a
-  /// static type as the effect's unique identifier.
+  /// A convenience for calling ``EffectPublisher/timer(id:every:tolerance:on:options:)-6yv2m`` with
+  /// a static type as the effect's unique identifier.
   ///
   /// - Parameters:
   ///   - id: A unique type identifying the effect.
@@ -123,11 +129,17 @@ extension Effect where Failure == Never {
   ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
   ///     allows any variance.
   ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
-  @available(iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
-  @available(tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead.")
   @available(
-    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'Effect.run', instead."
+    iOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    macOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    tvOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
+  )
+  @available(
+    watchOS, deprecated: 9999.0, message: "Use 'scheduler.timer' in 'EffectTask.run', instead."
   )
   public static func timer<S: Scheduler>(
     id: Any.Type,

--- a/Sources/ComposableArchitecture/Effects/TaskResult.swift
+++ b/Sources/ComposableArchitecture/Effects/TaskResult.swift
@@ -31,9 +31,9 @@ import XCTestDynamicOverlay
 /// }
 /// ```
 ///
-/// And finally you can use ``Effect/task(priority:operation:catch:file:fileID:line:)`` to construct
-/// an effect in the reducer that invokes the `numberFact` endpoint and wraps its response in a
-/// ``TaskResult`` by using its catching initializer, ``TaskResult/init(catching:)``:
+/// And finally you can use ``EffectPublisher/task(priority:operation:catch:file:fileID:line:)`` to
+/// construct an effect in the reducer that invokes the `numberFact` endpoint and wraps its response
+/// in a ``TaskResult`` by using its catching initializer, ``TaskResult/init(catching:)``:
 ///
 /// ```swift
 /// case .factButtonTapped:

--- a/Sources/ComposableArchitecture/Internal/Box.swift
+++ b/Sources/ComposableArchitecture/Internal/Box.swift
@@ -1,3 +1,4 @@
+@propertyWrapper
 final class Box<Wrapped> {
   var wrappedValue: Wrapped
 

--- a/Sources/ComposableArchitecture/Internal/Create.swift
+++ b/Sources/ComposableArchitecture/Internal/Create.swift
@@ -105,13 +105,13 @@ final class DemandBuffer<S: Subscriber>: @unchecked Sendable {
 
 extension AnyPublisher {
   private init(
-    _ callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable
+    _ callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
   ) {
     self = Publishers.Create(callback: callback).eraseToAnyPublisher()
   }
 
   static func create(
-    _ factory: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable
+    _ factory: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
   ) -> AnyPublisher<Output, Failure> {
     AnyPublisher(factory)
   }
@@ -119,9 +119,9 @@ extension AnyPublisher {
 
 extension Publishers {
   fileprivate class Create<Output, Failure: Swift.Error>: Publisher {
-    private let callback: (Effect<Output, Failure>.Subscriber) -> Cancellable
+    private let callback: (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable
 
-    init(callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable) {
+    init(callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable) {
       self.callback = callback
     }
 
@@ -138,7 +138,7 @@ extension Publishers.Create {
     private var cancellable: Cancellable?
 
     init(
-      callback: @escaping (Effect<Output, Failure>.Subscriber) -> Cancellable,
+      callback: @escaping (EffectPublisher<Output, Failure>.Subscriber) -> Cancellable,
       downstream: Downstream
     ) {
       self.buffer = DemandBuffer(subscriber: downstream)
@@ -169,7 +169,7 @@ extension Publishers.Create.Subscription: CustomStringConvertible {
   }
 }
 
-extension Effect {
+extension EffectPublisher {
   public struct Subscriber {
     private let _send: (Action) -> Void
     private let _complete: (Subscribers.Completion<Failure>) -> Void

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -482,19 +482,19 @@ extension TestStore {
 
 // MARK: - Deprecated after 0.38.2:
 
-extension Effect {
+extension EffectPublisher {
   @available(*, deprecated)
   public var upstream: AnyPublisher<Action, Failure> {
     self.publisher
   }
 }
 
-extension Effect where Failure == Error {
+extension EffectPublisher where Failure == Error {
   @_disfavoredOverload
   @available(
     *,
     deprecated,
-    message: "Use the non-failing version of 'Effect.task'"
+    message: "Use the non-failing version of 'EffectTask.task'"
   )
   public static func task(
     priority: TaskPriority? = nil,
@@ -552,7 +552,7 @@ extension Store {
 
 // MARK: - Deprecated after 0.38.0:
 
-extension Effect {
+extension EffectPublisher {
   @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
   @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
   @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
@@ -574,7 +574,7 @@ extension ViewStore {
 
 // MARK: - Deprecated after 0.34.0:
 
-extension Effect {
+extension EffectPublisher {
   @available(
     *,
     deprecated,

--- a/Sources/ComposableArchitecture/Internal/EnumTag.swift
+++ b/Sources/ComposableArchitecture/Internal/EnumTag.swift
@@ -1,0 +1,17 @@
+func enumTag<Case>(_ `case`: Case) -> UInt32? {
+  let metadataPtr = unsafeBitCast(type(of: `case`), to: UnsafeRawPointer.self)
+  let kind = metadataPtr.load(as: Int.self)
+  let isEnumOrOptional = kind == 0x201 || kind == 0x202
+  guard isEnumOrOptional else { return nil }
+  let vwtPtr = (metadataPtr - MemoryLayout<UnsafeRawPointer>.size).load(as: UnsafeRawPointer.self)
+  let vwt = vwtPtr.load(as: EnumValueWitnessTable.self)
+  return withUnsafePointer(to: `case`) { vwt.getEnumTag($0, metadataPtr) }
+}
+
+struct EnumValueWitnessTable {
+  let f1, f2, f3, f4, f5, f6, f7, f8: UnsafeRawPointer
+  let f9, f10: Int
+  let f11, f12: UInt32
+  let getEnumTag: @convention(c) (UnsafeRawPointer, UnsafeRawPointer) -> UInt32
+  let f13, f14: UnsafeRawPointer
+}

--- a/Sources/ComposableArchitecture/Internal/NavigationID.swift
+++ b/Sources/ComposableArchitecture/Internal/NavigationID.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension DependencyValues {
+  @usableFromInline
+  var navigationID: NavigationID {
+    get { self[NavigationID.self] }
+    set { self[NavigationID.self] = newValue }
+  }
+}
+
+// TODO: Fix sendability of (`AnyHashable`)
+public struct NavigationID: @unchecked Sendable {
+  public var current: AnyHashable?
+  public var next: @Sendable () -> AnyHashable
+}
+
+extension NavigationID: DependencyKey {
+  public static let liveValue = {
+    let id = UUIDGenerator { UUID() }
+    return Self { id() }
+  }()
+
+  public static var testValue = {
+    let id = UUIDGenerator.incrementing
+    return Self { id() }
+  }()
+}

--- a/Sources/ComposableArchitecture/Internal/OpenExistential.swift
+++ b/Sources/ComposableArchitecture/Internal/OpenExistential.swift
@@ -1,5 +1,31 @@
+import Foundation
+
 #if swift(>=5.7)
   // MARK: swift(>=5.7)
+  // MARK: Decodable
+
+  func _decode(_ type: Any.Type, from data: Data) throws -> Any? {
+    try (type as? any Decodable.Type)?.init(from: data)
+  }
+
+  extension Decodable {
+    fileprivate init(from data: Data) throws {
+      self = try decoder.decode(Self.self, from: data)
+    }
+  }
+
+  // MARK: Encodable
+
+  func _encode(_ value: Any) throws -> Data? {
+    try (value as? any Encodable)?.encode()
+  }
+
+  extension Encodable {
+    fileprivate func encode() throws -> Data {
+      try encoder.encode(self)
+    }
+  }
+
   // MARK: Equatable
 
   func _isEqual(_ lhs: Any, _ rhs: Any) -> Bool? {
@@ -16,6 +42,44 @@
   // MARK: swift(<5.7)
 
   private enum Witness<T> {}
+
+  // MARK: Decodable
+
+  func _decode(_ type: Any.Type, from data: Data) throws -> Any? {
+    func open<T>(_: T.Type) throws -> Any? {
+      try (Witness<T>.self as? AnyDecodable.Type)?.decode(from: data)
+    }
+    return try _openExistential(type, do: open)
+  }
+
+  private protocol AnyDecodable {
+    static func decode(from data: Data) throws -> Any
+  }
+
+  extension Witness: AnyDecodable where T: Decodable {
+    static func decode(from data: Data) throws -> Any {
+      try decoder.decode(T.self, from: data)
+    }
+  }
+
+  // MARK: Encodable
+
+  func _encode(_ value: Any) throws -> Data? {
+    func open<T>(_: T.Type) throws -> Data? {
+      try (Witness<T>.self as? AnyEncodable.Type)?.encode(value)
+    }
+    return try _openExistential(type(of: value), do: open)
+  }
+
+  private protocol AnyEncodable {
+    static func encode(_ value: Any) throws -> Data?
+  }
+
+  extension Witness: AnyEncodable where T: Encodable {
+    static func encode(_ value: Any) throws -> Data? {
+      try (value as? T).map(encoder.encode)
+    }
+  }
 
   // MARK: Equatable
 
@@ -40,3 +104,6 @@
     }
   }
 #endif
+
+private let decoder = JSONDecoder()
+private let encoder = JSONEncoder()

--- a/Sources/ComposableArchitecture/Internal/OptionalCache.swift
+++ b/Sources/ComposableArchitecture/Internal/OptionalCache.swift
@@ -1,0 +1,11 @@
+/// Creates a memoized cache that always returns the last non-`nil` value.
+///
+/// Useful for preserving a presented UI during the programmatic dismissal of sheets and other forms
+/// of navigation, where setting state to `nil` drives dismissal.
+func returningLastNonNilValue<A, B>(_ f: @escaping (A) -> B?) -> (A) -> B? {
+  var lastWrapped: B?
+  return { wrapped in
+    lastWrapped = f(wrapped) ?? lastWrapped
+    return lastWrapped
+  }
+}

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -60,8 +60,8 @@ import Combine
 public struct AnyReducer<State, Action, Environment> {
   private let reducer: (inout State, Action, Environment) -> EffectTask<Action>
 
-  /// > This API has been soft-deprecated in favor of ``ReducerProtocol``.
-  /// Read <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``ReducerProtocol``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Initializes a reducer from a simple reducer function signature.
   ///
@@ -128,8 +128,8 @@ public struct AnyReducer<State, Action, Environment> {
     self.reducer = reducer
   }
 
-  /// This API has been soft-deprecated in favor of ``EmptyReducer``.
-  /// Read <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``EmptyReducer``. Read <doc:ReducerProtocol>
+  /// > for more information.
   ///
   /// A reducer that performs no state mutations and returns no effects.
   @available(
@@ -168,8 +168,8 @@ public struct AnyReducer<State, Action, Environment> {
     Self { _, _, _ in .none }
   }
 
-  /// This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``.
+  /// > Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Combines many reducers into a single one by running each one on state in order, and merging
   /// all of the effects.
@@ -258,8 +258,8 @@ public struct AnyReducer<State, Action, Environment> {
     .combine(reducers)
   }
 
-  /// This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``.
+  /// > Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Combines many reducers into a single one by running each one on state in order, and merging
   /// all of the effects.
@@ -308,8 +308,8 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of combining reducers in a ``ReducerBuilder``.
+  /// > Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Combines the receiving reducer with one other reducer, running the second after the first and
   /// merging all of the effects.
@@ -359,8 +359,8 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of ``Scope``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``Scope``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Transforms a reducer that works on child state, action, and environment into one that works on
   /// parent state, action and environment. It accomplishes this by providing 3 transformations to
@@ -449,10 +449,10 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of
-  /// ``ReducerProtocol/ifCaseLet(_:action:then:file:fileID:line:)`` and
-  /// ``Scope/init(state:action:_:file:fileID:line:)``. Read <doc:MigratingToTheReducerProtocol>
-  /// for more information.
+  /// > This API has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/ifCaseLet(_:action:then:file:fileID:line:)`` and
+  /// > ``Scope/init(state:action:_:file:fileID:line:)``. Read <doc:MigratingToTheReducerProtocol>
+  /// > for more information.
   ///
   /// Transforms a reducer that works on child state, action, and environment into one that works on
   /// parent state, action and environment.
@@ -710,9 +710,9 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of
-  /// ``ReducerProtocol/ifLet(_:action:then:file:fileID:line:)``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/ifLet(_:action:then:file:fileID:line:)``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Transforms a reducer that works on non-optional state into one that works on optional state by
   /// only running the non-optional reducer when state is non-nil.
@@ -941,9 +941,9 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of
-  /// ``ReducerProtocol/forEach(_:action:_:file:fileID:line:)``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/forEach(_:action:_:file:fileID:line:)``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// A version of ``pullback(state:action:environment:)`` that transforms a reducer that works on
   /// an element into one that works on an identified array of elements.
@@ -1135,8 +1135,9 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
-  /// Read <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/reduce(into:action:)-8yinq``. Read <doc:MigratingToTheReducerProtocol>
+  /// > for more information.
   ///
   /// Runs the reducer.
   ///
@@ -1185,8 +1186,9 @@ public struct AnyReducer<State, Action, Environment> {
     self.reducer(&state, action, environment)
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
-  /// Read <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/reduce(into:action:)-8yinq``. Read <doc:MigratingToTheReducerProtocol> for
+  /// > more information.
   @available(
     iOS,
     deprecated: 9999.0,

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -5,15 +5,15 @@ import Combine
 /// Read <doc:MigratingToTheReducerProtocol> for more information.
 ///
 /// A reducer describes how to evolve the current state of an application to the next state, given
-/// an action, and describes what ``Effect``s should be executed later by the store, if any.
+/// an action, and describes what ``EffectTask``s should be executed later by the store, if any.
 ///
 /// Reducers have 3 generics:
 ///
 ///   * `State`: A type that holds the current state of the application.
 ///   * `Action`: A type that holds all possible actions that cause the state of the application to
 ///     change.
-///   * `Environment`: A type that holds all dependencies needed in order to produce ``Effect``s,
-///     such as API clients, analytics clients, random number generators, etc.
+///   * `Environment`: A type that holds all dependencies needed in order to produce
+///     ``EffectTask``s, such as API clients, analytics clients, random number generators, etc.
 ///
 /// > Important: The thread on which effects output is important. An effect's output is immediately
 ///   sent back into the store, and ``Store`` is not thread safe. This means all effects must
@@ -21,9 +21,10 @@ import Combine
 ///   output must be on the main thread. You can use the `Publisher` method `receive(on:)` for make
 ///   the effect output its values on the thread of your choice.
 /// >
-/// > This is only an issue if using the Combine interface of ``Effect`` as mentioned above. If you
-///   you are only using Swift's concurrency tools and the `.task`, `.run` and `.fireAndForget`
-///   functions on ``Effect``, then the threading is automatically handled for you.
+/// > This is only an issue if using the Combine interface of ``EffectPublisher`` as mentioned
+///   above. If you are only using Swift's concurrency tools and the `.task`, `.run` and
+///   `.fireAndForget` functions on ``EffectTask``, then the threading is automatically handled for
+///   you.
 @available(
   iOS,
   deprecated: 9999.0,
@@ -57,7 +58,7 @@ import Combine
     """
 )
 public struct AnyReducer<State, Action, Environment> {
-  private let reducer: (inout State, Action, Environment) -> Effect<Action, Never>
+  private let reducer: (inout State, Action, Environment) -> EffectTask<Action>
 
   /// > This API has been soft-deprecated in favor of ``ReducerProtocol``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
@@ -67,7 +68,7 @@ public struct AnyReducer<State, Action, Environment> {
   /// The reducer takes three arguments: state, action and environment. The state is `inout` so that
   /// you can make any changes to it directly inline. The reducer must return an effect, which
   /// typically would be constructed by using the dependencies inside the `environment` value. If
-  /// no effect needs to be executed, a ``Effect/none`` effect can be returned.
+  /// no effect needs to be executed, a ``EffectPublisher/none`` effect can be returned.
   ///
   /// For example:
   ///
@@ -123,7 +124,7 @@ public struct AnyReducer<State, Action, Environment> {
       This API has been soft-deprecated in favor of 'ReducerProtocol'. Read the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
       """
   )
-  public init(_ reducer: @escaping (inout State, Action, Environment) -> Effect<Action, Never>) {
+  public init(_ reducer: @escaping (inout State, Action, Environment) -> EffectTask<Action>) {
     self.reducer = reducer
   }
 
@@ -1134,7 +1135,7 @@ public struct AnyReducer<State, Action, Environment> {
     }
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-4nzr2``.
+  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Runs the reducer.
@@ -1180,11 +1181,11 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> Effect<Action, Never> {
+  ) -> EffectTask<Action> {
     self.reducer(&state, action, environment)
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-4nzr2``.
+  /// This API has been soft-deprecated in favor of ``ReducerProtocol/reduce(into:action:)-8yinq``.
   /// Read <doc:MigratingToTheReducerProtocol> for more information.
   @available(
     iOS,
@@ -1222,7 +1223,7 @@ public struct AnyReducer<State, Action, Environment> {
     _ state: inout State,
     _ action: Action,
     _ environment: Environment
-  ) -> Effect<Action, Never> {
+  ) -> EffectTask<Action> {
     self.reducer(&state, action, environment)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerBinding.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerBinding.swift
@@ -1,6 +1,6 @@
 extension AnyReducer where Action: BindableAction, State == Action.State {
-  /// This API has been soft-deprecated in favor of ``BindingReducer``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``BindingReducer``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Returns a reducer that applies ``BindingAction`` mutations to `State` before running this
   /// reducer's logic.

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerDebug.swift
@@ -2,8 +2,8 @@ import CasePaths
 import Dispatch
 
 extension AnyReducer {
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/debug()``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``ReducerProtocol/debug()``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Prints debug messages describing all received actions and state mutations.
   ///
@@ -64,8 +64,8 @@ extension AnyReducer {
     )
   }
 
-  /// The API that used this type has been soft-deprecated in favor of ``ReducerProtocol/debug()``.
-  /// Read <doc:MigratingToTheReducerProtocol> for more information.
+  /// > The API that used this type has been soft-deprecated in favor of
+  /// > ``ReducerProtocol/debug()``. Read <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Prints debug messages describing all received actions.
   ///
@@ -126,8 +126,8 @@ extension AnyReducer {
     )
   }
 
-  /// This API has been soft-deprecated in favor of ``ReducerProtocol/debug()``. Read
-  /// <doc:MigratingToTheReducerProtocol> for more information.
+  /// > This API has been soft-deprecated in favor of ``ReducerProtocol/debug()``. Read
+  /// > <doc:MigratingToTheReducerProtocol> for more information.
   ///
   /// Prints debug messages describing all received actions and state mutations.
   ///
@@ -287,9 +287,8 @@ public enum ActionFormat: Sendable {
   case prettyPrint
 }
 
-/// The API that used this type has been soft-deprecated in favor of
-/// ``ReducerProtocol/debug()`` Read <doc:MigratingToTheReducerProtocol> for more
-/// information.
+/// > The API that used this type has been soft-deprecated in favor of
+/// > ``ReducerProtocol/debug()`` Read <doc:MigratingToTheReducerProtocol> for more information.
 ///
 /// An environment for debug-printing reducers.
 @available(

--- a/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
+++ b/Sources/ComposableArchitecture/Reducer/AnyReducer/AnyReducerSignpost.swift
@@ -85,7 +85,7 @@ extension AnyReducer {
   }
 }
 
-extension Effect where Failure == Never {
+extension EffectPublisher where Failure == Never {
   @usableFromInline
   func effectSignpost(
     _ prefix: String,

--- a/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
+++ b/Sources/ComposableArchitecture/Reducer/ReducerBuilder.swift
@@ -98,8 +98,8 @@ public enum ReducerBuilder<State, Action> {
     case second(Second)
 
     @inlinable
-    public func reduce(into state: inout First.State, action: First.Action) -> Effect<
-      First.Action, Never
+    public func reduce(into state: inout First.State, action: First.Action) -> EffectTask<
+      First.Action
     > {
       switch self {
       case let .first(first):
@@ -123,7 +123,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Wrapped.State, action: Wrapped.Action
-    ) -> Effect<Wrapped.Action, Never> {
+    ) -> EffectTask<Wrapped.Action> {
       switch wrapped {
       case let .some(wrapped):
         return wrapped.reduce(into: &state, action: action)
@@ -148,7 +148,7 @@ public enum ReducerBuilder<State, Action> {
     }
 
     @inlinable
-    public func reduce(into state: inout R0.State, action: R0.Action) -> Effect<R0.Action, Never> {
+    public func reduce(into state: inout R0.State, action: R0.Action) -> EffectTask<R0.Action> {
       self.r0.reduce(into: &state, action: action)
         .merge(with: self.r1.reduce(into: &state, action: action))
     }
@@ -166,7 +166,7 @@ public enum ReducerBuilder<State, Action> {
     @inlinable
     public func reduce(
       into state: inout Element.State, action: Element.Action
-    ) -> Effect<Element.Action, Never> {
+    ) -> EffectTask<Element.Action> {
       self.reducers.reduce(.none) { $0.merge(with: $1.reduce(into: &state, action: action)) }
     }
   }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/BindingReducer.swift
@@ -15,7 +15,7 @@ where Action: BindableAction, State == Action.State {
   @inlinable
   public func reduce(
     into state: inout State, action: Action
-  ) -> Effect<Action, Never> {
+  ) -> EffectTask<Action> {
     guard let bindingAction = (/Action.binding).extract(from: action)
     else { return .none }
 

--- a/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/CombineReducers.swift
@@ -37,7 +37,7 @@ public struct CombineReducers<Reducers: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Reducers.State, action: Reducers.Action
-  ) -> Effect<Reducers.Action, Never> {
+  ) -> EffectTask<Reducers.Action> {
     self.reducers.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -66,7 +66,7 @@ public struct _PrintChangesReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectTask<Base.Action> {
     #if DEBUG
       if self.context != .test, let printer = self.printer {
         let oldState = state

--- a/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/DependencyKeyWritingReducer.swift
@@ -145,7 +145,7 @@ public struct _DependencyKeyWritingReducer<Base: ReducerProtocol>: ReducerProtoc
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectTask<Base.Action> {
     DependencyValues.withValues {
       self.update(&$0)
     } operation: {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/EmptyReducer.swift
@@ -13,7 +13,7 @@ public struct EmptyReducer<State, Action>: ReducerProtocol {
   init(internal: Void) {}
 
   @inlinable
-  public func reduce(into _: inout State, action _: Action) -> Effect<Action, Never> {
+  public func reduce(into _: inout State, action _: Action) -> EffectTask<Action> {
     .none
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -140,7 +140,7 @@ public struct _ForEachReducer<
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceForEach(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -148,7 +148,7 @@ public struct _ForEachReducer<
   @inlinable
   func reduceForEach(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     guard let (id, elementAction) = self.toElementAction.extract(from: action) else { return .none }
     if state[keyPath: self.toElementsState][id: id] == nil {
       runtimeWarn(

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -134,7 +134,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -142,7 +142,7 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard var childState = self.toChildState.extract(from: state) else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -131,7 +131,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   public func reduce(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     self.reduceChild(into: &state, action: action)
       .merge(with: self.parent.reduce(into: &state, action: action))
   }
@@ -139,7 +139,7 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
   @inlinable
   func reduceChild(
     into state: inout Parent.State, action: Parent.Action
-  ) -> Effect<Parent.Action, Never> {
+  ) -> EffectTask<Parent.Action> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     guard state[keyPath: self.toChildState] != nil else {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Observe.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Observe.swift
@@ -1,0 +1,21 @@
+public struct _Observe<Reducers: ReducerProtocol>: ReducerProtocol {
+  @usableFromInline
+  let reducers: (State, Action) -> Reducers
+
+  /// Initializes a reducer that builds a reducer from the current state and action.
+  ///
+  /// - Parameter build: A reducer builder that has access to the current state and action.
+  @inlinable
+  public init<State, Action>(
+    @ReducerBuilder<State, Action> _ build: @escaping (State, Action) -> Reducers
+  ) where Reducers.State == State, Reducers.Action == Action {
+    self.reducers = build
+  }
+
+  @inlinable
+  public func reduce(
+    into state: inout Reducers.State, action: Reducers.Action
+  ) -> Effect<Reducers.Action, Never> {
+    self.reducers(state, action).reduce(into: &state, action: action)
+  }
+}

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Reduce.swift
@@ -4,11 +4,11 @@
 /// a new type that conforms to ``ReducerProtocol``.
 public struct Reduce<State, Action>: ReducerProtocol {
   @usableFromInline
-  let reduce: (inout State, Action) -> Effect<Action, Never>
+  let reduce: (inout State, Action) -> EffectTask<Action>
 
   @usableFromInline
   init(
-    internal reduce: @escaping (inout State, Action) -> Effect<Action, Never>
+    internal reduce: @escaping (inout State, Action) -> EffectTask<Action>
   ) {
     self.reduce = reduce
   }
@@ -17,7 +17,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   ///
   /// - Parameter reduce: A function that is called when ``reduce(into:action:)`` is invoked.
   @inlinable
-  public init(_ reduce: @escaping (inout State, Action) -> Effect<Action, Never>) {
+  public init(_ reduce: @escaping (inout State, Action) -> EffectTask<Action>) {
     self.init(internal: reduce)
   }
 
@@ -31,7 +31,7 @@ public struct Reduce<State, Action>: ReducerProtocol {
   }
 
   @inlinable
-  public func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  public func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     self.reduce(&state, action)
   }
 }

--- a/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -233,7 +233,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
   @inlinable
   public func reduce(
     into state: inout ParentState, action: ParentAction
-  ) -> Effect<ParentAction, Never> {
+  ) -> EffectTask<ParentAction> {
     guard let childAction = self.toChildAction.extract(from: action)
     else { return .none }
     switch self.toChildState {

--- a/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
+++ b/Sources/ComposableArchitecture/Reducer/Reducers/SignpostReducer.swift
@@ -58,7 +58,7 @@ public struct _SignpostReducer<Base: ReducerProtocol>: ReducerProtocol {
   @inlinable
   public func reduce(
     into state: inout Base.State, action: Base.Action
-  ) -> Effect<Base.Action, Never> {
+  ) -> EffectTask<Base.Action> {
     var actionOutput: String!
     if self.log.signpostsEnabled {
       actionOutput = debugCaseOutput(action)

--- a/Sources/ComposableArchitecture/ReducerProtocol.swift
+++ b/Sources/ComposableArchitecture/ReducerProtocol.swift
@@ -1,6 +1,7 @@
 #if compiler(>=5.7)
   /// A protocol that describes how to evolve the current state of an application to the next state,
-  /// given an action, and describes what ``Effect``s should be executed later by the store, if any.
+  /// given an action, and describes what ``EffectTask``s should be executed later by the store, if
+  /// any.
   ///
   /// Conform types to this protocol to represent the domain, logic and behavior for your feature.
   /// The domain is specified by the "state" and "actions", which can be nested types inside the
@@ -22,13 +23,13 @@
   ///
   /// The logic of your feature is implemented by mutating the feature's current state when an action
   /// comes into the system. This is most easily done by implementing the
-  /// ``ReducerProtocol/reduce(into:action:)-4nzr2`` method of the protocol.
+  /// ``ReducerProtocol/reduce(into:action:)-8yinq`` method of the protocol.
   ///
   /// ```swift
   /// struct Feature: ReducerProtocol {
   ///   // ...
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -45,7 +46,7 @@
   /// The `reduce` method's first responsibility is to mutate the feature's current state given an
   /// action. It's second responsibility is to return effects that will be executed asynchronously
   /// and feed their data back into the system. Currently `Feature` does not need to run any effects,
-  /// and so ``Effect/none`` is returned.
+  /// and so ``EffectPublisher/none`` is returned.
   ///
   /// If the feature does need to do effectful work, then more would need to be done. For example,
   /// suppose the feature has the ability to start and stop a timer, and with each tick of the timer
@@ -65,7 +66,7 @@
   ///   }
   ///   enum TimerID {}
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .decrementButtonTapped:
   ///       state.count -= 1
@@ -104,16 +105,16 @@
   /// That is the basics of implementing a feature as a conformance to ``ReducerProtocol``. There are
   /// actually two ways to define a reducer:
   ///
-  ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, as shown above, which
+  ///   1. You can either implement the ``reduce(into:action:)-8yinq`` method, as shown above, which
   ///   is given direct mutable access to application ``State`` whenever an ``Action`` is fed into
-  ///   the system, and returns an ``Effect`` that can communicate with the outside world and feed
-  ///   additional ``Action``s back into the system.
+  ///   the system, and returns an ``EffectTask`` that can communicate with the outside world and
+  ///   feed additional ``Action``s back into the system.
   ///
   ///   2. Or you can implement the ``body-swift.property-7foai`` property, which combines one or
   ///   more reducers together.
   ///
   /// At most one of these requirements should be implemented. If a conformance implements both
-  /// requirements, only ``reduce(into:action:)-4nzr2`` will be called by the ``Store``. If your
+  /// requirements, only ``reduce(into:action:)-8yinq`` will be called by the ``Store``. If your
   /// reducer assembles a body from other reducers _and_ has additional business logic it needs to
   /// layer onto the feature, introduce this logic into the body instead, either with ``Reduce``:
   ///
@@ -138,13 +139,13 @@
   ///   Settings()
   /// }
   ///
-  /// func core(state: inout State, action: Action) -> Effect<Action, Never> {
+  /// func core(state: inout State, action: Action) -> EffectTask<Action> {
   ///   // extra logic
   /// }
   /// ```
   ///
   /// If you are implementing a custom reducer operator that transforms an existing reducer,
-  /// _always_ invoke the ``reduce(into:action:)-4nzr2`` method, never the
+  /// _always_ invoke the ``reduce(into:action:)-8yinq`` method, never the
   /// ``body-swift.property-7foai``. For example, this operator that logs all actions sent to the
   /// reducer:
   ///
@@ -164,7 +165,7 @@
     associatedtype State
 
     /// A type that holds all possible actions that cause the ``State`` of the reducer to change
-    /// and/or kick off a side ``Effect`` that can communicate with the outside world.
+    /// and/or kick off a side ``EffectTask`` that can communicate with the outside world.
     associatedtype Action
 
     // NB: For Xcode to favor autocompleting `var body: Body` over `var body: Never` we must use a
@@ -176,7 +177,7 @@
     /// When you create a custom reducer by implementing the ``body-swift.property-7foai``, Swift
     /// infers this type from the value returned.
     ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-4nzr2``, Swift
+    /// If you create a custom reducer by implementing the ``reduce(into:action:)-8yinq``, Swift
     /// infers this type to be `Never`.
     typealias Body = _Body
 
@@ -192,7 +193,7 @@
     ///     side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never>
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -201,8 +202,8 @@
     ///
     /// Do not invoke this property directly.
     ///
-    /// > Important: if your reducer implements the ``reduce(into:action:)-4nzr2`` method, it will
-    /// > take precedence over this property, and only ``reduce(into:action:)-4nzr2`` will be called
+    /// > Important: if your reducer implements the ``reduce(into:action:)-8yinq`` method, it will
+    /// > take precedence over this property, and only ``reduce(into:action:)-8yinq`` will be called
     /// > by the ``Store``. If your reducer assembles a body from other reducers and has additional
     /// > business logic it needs to layer into the system, introduce this logic into the body
     /// > instead, either with ``Reduce``, or with a separate, dedicated conformance.
@@ -211,20 +212,21 @@
   }
 #else
   /// A protocol that describes how to evolve the current state of an application to the next state,
-  /// given an action, and describes what ``Effect``s should be executed later by the store, if any.
+  /// given an action, and describes what ``EffectTask``s should be executed later by the store, if
+  /// any.
   ///
   /// There are two ways to define a reducer:
   ///
-  ///   1. You can either implement the ``reduce(into:action:)-4nzr2`` method, which is given direct
+  ///   1. You can either implement the ``reduce(into:action:)-8yinq`` method, which is given direct
   ///      mutable access to application ``State`` whenever an ``Action`` is fed into the system,
-  ///      and returns an ``Effect`` that can communicate with the outside world and feed additional
-  ///      ``Action``s back into the system.
+  ///      and returns an ``EffectTask`` that can communicate with the outside world and feed
+///        additional ``Action``s back into the system.
   ///
   ///   2. Or you can implement the ``body-swift.property-7foai`` property, which combines one or
   ///      more reducers together.
   ///
   /// At most one of these requirements should be implemented. If a conformance implements both
-  /// requirements, only ``reduce(into:action:)-4nzr2`` will be called by the ``Store``. If your
+  /// requirements, only ``reduce(into:action:)-8yinq`` will be called by the ``Store``. If your
   /// reducer assembles a body from other reducers _and_ has additional business logic it needs to
   /// layer onto the feature, introduce this logic into the body instead, either with ``Reduce``:
   ///
@@ -254,7 +256,7 @@
   /// ```
   ///
   /// If you are implementing a custom reducer operator that transforms an existing reducer,
-  /// _always_ invoke the ``reduce(into:action:)-4nzr2`` method, never the
+  /// _always_ invoke the ``reduce(into:action:)-8yinq`` method, never the
   /// ``body-swift.property-7foai``. For example, this operator that logs all actions sent to the
   /// reducer:
   ///
@@ -273,7 +275,7 @@
     associatedtype State
 
     /// A type that holds all possible actions that cause the ``State`` of the reducer to change
-    /// and/or kick off a side ``Effect`` that can communicate with the outside world.
+    /// and/or kick off a side ``EffectTask`` that can communicate with the outside world.
     associatedtype Action
 
     // NB: For Xcode to favor autocompleting `var body: Body` over `var body: Never` we must use a
@@ -285,7 +287,7 @@
     /// When you create a custom reducer by implementing the ``body-swift.property-7foai``, Swift
     /// infers this type from the value returned.
     ///
-    /// If you create a custom reducer by implementing the ``reduce(into:action:)-4nzr2``, Swift
+    /// If you create a custom reducer by implementing the ``reduce(into:action:)-8yinq``, Swift
     /// infers this type to be `Never`.
     typealias Body = _Body
 
@@ -301,7 +303,7 @@
     ///     a side effect that can communicate with the outside world.
     /// - Returns: An effect that can communicate with the outside world and feed actions back into
     ///   the system.
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never>
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action>
 
     /// The content and behavior of a reducer that is composed from other reducers.
     ///
@@ -310,8 +312,8 @@
     ///
     /// Do not invoke this property directly.
     ///
-    /// > Important: if your reducer implements the ``reduce(into:action:)-4nzr2`` method, it will
-    /// > take precedence over this property, and only ``reduce(into:action:)-4nzr2`` will be called
+    /// > Important: if your reducer implements the ``reduce(into:action:)-8yinq`` method, it will
+    /// > take precedence over this property, and only ``reduce(into:action:)-8yinq`` will be called
     /// > by the ``Store``. If your reducer assembles a body from other reducers and has additional
     /// > business logic it needs to layer into the system, introduce this logic into the body
     /// > instead, either with ``Reduce``, or with a separate, dedicated conformance.
@@ -338,11 +340,11 @@ extension ReducerProtocol where Body == Never {
 }
 
 extension ReducerProtocol where Body: ReducerProtocol, Body.State == State, Body.Action == Action {
-  /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-4nzr2``.
+  /// Invokes the ``Body-40qdd``'s implementation of ``reduce(into:action:)-8yinq``.
   @inlinable
   public func reduce(
     into state: inout Body.State, action: Body.Action
-  ) -> Effect<Body.Action, Never> {
+  ) -> EffectTask<Body.Action> {
     self.body.reduce(into: &state, action: action)
   }
 }

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -128,7 +128,7 @@ public final class Store<State, Action> {
   #if swift(>=5.7)
     private let reducer: any ReducerProtocol<State, Action>
   #else
-    private let reducer: (inout State, Action) -> Effect<Action, Never>
+    private let reducer: (inout State, Action) -> EffectTask<Action>
     fileprivate var scope: AnyStoreScope?
   #endif
   var state: CurrentValueSubject<State, Never>
@@ -603,7 +603,7 @@ public typealias StoreOf<R: ReducerProtocol> = Store<R.State, R.Action>
     @inlinable
     func reduce(
       into state: inout ScopedState, action: ScopedAction
-    ) -> Effect<ScopedAction, Never> {
+    ) -> EffectTask<ScopedAction> {
       self.isSending = true
       defer {
         state = self.toScopedState(self.rootStore.state.value)

--- a/Sources/ComposableArchitecture/SwiftUI/Alert.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Alert.swift
@@ -39,7 +39,7 @@ import SwiftUI
 /// to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.alert = nil

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -40,7 +40,7 @@ import SwiftUI
 /// you want to show to the user:
 ///
 /// ```swift
-/// func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
 ///   switch action {
 ///   case .cancelTapped:
 ///     state.confirmationDialog = nil

--- a/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ConfirmationDialog.swift
@@ -165,10 +165,7 @@ public struct ConfirmationDialogState<Action> {
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
 extension ConfirmationDialogState: CustomDumpReflectable {
   public var customDumpMirror: Mirror {
     Mirror(
@@ -183,10 +180,7 @@ extension ConfirmationDialogState: CustomDumpReflectable {
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
 extension ConfirmationDialogState: Equatable where Action: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.title == rhs.title
@@ -195,10 +189,7 @@ extension ConfirmationDialogState: Equatable where Action: Equatable {
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
 extension ConfirmationDialogState: Hashable where Action: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.title)
@@ -207,10 +198,7 @@ extension ConfirmationDialogState: Hashable where Action: Hashable {
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
 extension ConfirmationDialogState: Identifiable {}
 
 extension View {
@@ -222,10 +210,7 @@ extension View {
   ///   - dismissal: An action to send when the dialog is dismissed through non-user actions, such
   ///     as when a dialog is automatically dismissed by the system. Use this action to `nil` out
   ///     the associated dialog state.
-  @available(iOS 13, *)
-  @available(macOS 12, *)
-  @available(tvOS 13, *)
-  @available(watchOS 6, *)
+  @available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
   @ViewBuilder public func confirmationDialog<Action>(
     _ store: Store<ConfirmationDialogState<Action>?, Action>,
     dismiss: Action
@@ -234,7 +219,8 @@ extension View {
       self.modifier(
         NewConfirmationDialogModifier(
           viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-          dismiss: dismiss
+          dismiss: dismiss,
+          fromDialogAction: { $0 }
         )
       )
     } else {
@@ -242,19 +228,60 @@ extension View {
         self.modifier(
           OldConfirmationDialogModifier(
             viewStore: ViewStore(store, removeDuplicates: { $0?.id == $1?.id }),
-            dismiss: dismiss
+            dismiss: dismiss,
+            fromDialogAction: { $0 }
           )
         )
       #endif
+    }
+  }
+
+  @available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
+  @ViewBuilder public func confirmationDialog<State, Action, DialogAction>(
+    store: Store<
+      PresentationState<ConfirmationDialogState<DialogAction>>,
+      PresentationAction<ConfirmationDialogState<DialogAction>, DialogAction>
+    >
+  ) -> some View {
+    self.confirmationDialog(store: store, state: { $0 }, action: { $0 })
+  }
+
+  @available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
+  @ViewBuilder public func confirmationDialog<State, Action, DialogAction>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    state toDialogState: @escaping (State) -> ConfirmationDialogState<DialogAction>?,
+    action fromDialogAction: @escaping (DialogAction) -> Action
+  ) -> some View {
+    let viewStore = ViewStore(
+      store.scope(state: { $0.wrappedValue.flatMap(toDialogState) }),
+      removeDuplicates: { $0?.id == $1?.id }
+    )
+    if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+      self.modifier(
+        NewConfirmationDialogModifier(
+          viewStore: viewStore,
+          dismiss: .dismiss,
+          fromDialogAction: { .presented(fromDialogAction($0)) }
+        )
+      )
+    } else {
+      self.modifier(
+        OldConfirmationDialogModifier(
+          viewStore: viewStore,
+          dismiss: .dismiss,
+          fromDialogAction: { .presented(fromDialogAction($0)) }
+        )
+      )
     }
   }
 }
 
 // NB: Workaround for iOS 14 runtime crashes during iOS 15 availability checks.
 @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-private struct NewConfirmationDialogModifier<Action>: ViewModifier {
-  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+private struct NewConfirmationDialogModifier<Action, DialogAction>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<DialogAction>?, Action>
   let dismiss: Action
+  let fromDialogAction: (DialogAction) -> Action
 
   func body(content: Content) -> some View {
     content.confirmationDialog(
@@ -262,24 +289,22 @@ private struct NewConfirmationDialogModifier<Action>: ViewModifier {
       isPresented: viewStore.binding(send: dismiss).isPresent(),
       titleVisibility: viewStore.state?.titleVisibility.toSwiftUI ?? .automatic,
       presenting: viewStore.state,
-      actions: { $0.toSwiftUIActions(send: { viewStore.send($0) }) },
+      actions: { $0.toSwiftUIActions(send: { viewStore.send(self.fromDialogAction($0)) }) },
       message: { $0.message.map { Text($0) } }
     )
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
-private struct OldConfirmationDialogModifier<Action>: ViewModifier {
-  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<Action>?, Action>
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
+private struct OldConfirmationDialogModifier<Action, DialogAction>: ViewModifier {
+  @ObservedObject var viewStore: ViewStore<ConfirmationDialogState<DialogAction>?, Action>
   let dismiss: Action
+  let fromDialogAction: (DialogAction) -> Action
 
   func body(content: Content) -> some View {
     #if !os(macOS)
       return content.actionSheet(item: viewStore.binding(send: dismiss)) { state in
-        state.toSwiftUIActionSheet(send: { viewStore.send($0) })
+        state.toSwiftUIActionSheet(send: { viewStore.send(self.fromDialogAction($0)) })
       }
     #else
       return EmptyView()
@@ -287,10 +312,7 @@ private struct OldConfirmationDialogModifier<Action>: ViewModifier {
   }
 }
 
-@available(iOS 13, *)
-@available(macOS 12, *)
-@available(tvOS 13, *)
-@available(watchOS 6, *)
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
 extension ConfirmationDialogState {
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   @ViewBuilder

--- a/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/ForEachStore.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///     case descriptionChanged(String)
 ///   }
 ///
-///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> { ... }
+///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> { ... }
 /// }
 /// ```
 ///

--- a/Sources/ComposableArchitecture/SwiftUI/Navigation.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Navigation.swift
@@ -1,0 +1,526 @@
+import OrderedCollections
+import SwiftUI
+
+// TODO: Other names? `NavigationPathState`? `NavigationStatePath`?
+// TODO: Should `NavigationState` flatten to just work on `Identifiable` elements?
+// TODO: `Sendable where Element: Sendable`
+// TODO: Get a better handle on how explicit `ID`s are handled for various navigation scenarios.
+@propertyWrapper
+public struct NavigationState<Element: Hashable>:
+  MutableCollection,
+  RandomAccessCollection,
+  RangeReplaceableCollection
+{
+  public typealias ID = AnyHashable
+
+  public struct Destination: Identifiable {
+    public let id: ID
+    public var element: Element
+
+    @usableFromInline
+    init(id: ID? = nil, element: Element) {
+      self.id = id ?? DependencyValues._current.navigationID.next()
+      self.element = element
+    }
+  }
+
+  // TODO: should this be an array of reference boxed values?
+  // TODO: should this be publicly exposed?
+  @usableFromInline
+  var destinations: OrderedDictionary<ID, Element> = [:]
+
+  @inlinable
+  @inline(__always)
+  public var ids: OrderedSet<ID> {
+    self.destinations.keys
+  }
+
+  @inlinable
+  @inline(__always)
+  public var elements: [Element] {
+    self.destinations.values.elements
+  }
+
+  @inlinable
+  public init() {}
+
+  @inlinable
+  public subscript(id id: ID) -> Element? {
+    _read { yield self.destinations[id] }
+    _modify { yield &self.destinations[id] }
+  }
+
+  @discardableResult
+  @inlinable
+  public mutating func append(_ element: Element) -> ID {
+    let destination = Destination(element: element)
+    self.destinations[destination.id] = destination.element
+    return destination.id
+  }
+
+  @inlinable
+  @inline(__always)
+  public var startIndex: Int {
+    self.destinations.elements.startIndex
+  }
+
+  @inlinable
+  @inline(__always)
+  public var endIndex: Int {
+    self.destinations.elements.endIndex
+  }
+
+  @inlinable
+  @inline(__always)
+  public func index(after i: Int) -> Int {
+    self.destinations.elements.index(after: i)
+  }
+
+  @inlinable
+  public subscript(position: Int) -> Destination {
+    _read {
+      yield Destination(
+        id: self.destinations.keys[position], element: self.destinations.values[position]
+      )
+    }
+    _modify {
+      var destination = Destination(
+        id: self.destinations.keys[position], element: self.destinations.values[position]
+      )
+      yield &destination
+      self.destinations[destination.id] = destination.element
+    }
+    set {
+      let (_, index) = self.destinations.updateValue(
+        newValue.element, forKey: newValue.id, insertingAt: position
+      )
+      // TODO: Runtime warning finesse?
+      assert(index == position)
+    }
+  }
+
+  @inlinable
+  public mutating func replaceSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C)
+  where C.Element == Destination {
+    self.destinations.removeSubrange(subrange)
+    for destination in newElements.reversed() {
+      self.destinations.updateValue(
+        destination.element, forKey: destination.id, insertingAt: subrange.startIndex
+      )
+    }
+  }
+
+  @inlinable
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    self.destinations.swapAt(i, j)
+  }
+
+  public struct Path:
+    MutableCollection,
+    RandomAccessCollection,
+    RangeReplaceableCollection
+  {
+    @usableFromInline
+    var state: NavigationState
+
+    @inlinable
+    init(state: NavigationState) {
+      self.state = state
+    }
+
+    @inlinable
+    public init() { self.state = NavigationState() }
+
+    @inlinable
+    @inline(__always)
+    public var startIndex: Int {
+      self.state.startIndex
+    }
+
+    @inlinable
+    @inline(__always)
+    public var endIndex: Int {
+      self.state.endIndex
+    }
+
+    @inlinable
+    @inline(__always)
+    public func index(after i: Int) -> Int {
+      self.state.index(after: i)
+    }
+
+    @inlinable
+    public subscript(position: Int) -> Element {
+      _read { yield self.state[position].element }
+      _modify { yield &self.state[position].element }
+      set { self.state[position].element = newValue }
+    }
+
+    @inlinable
+    public mutating func replaceSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C)
+    where C.Element == Element {
+      self.state.replaceSubrange(subrange, with: newElements.map { Destination(element: $0) })
+    }
+
+    @inlinable
+    public mutating func swapAt(_ i: Int, _ j: Int) {
+      self.state.swapAt(i, j)
+    }
+  }
+
+  @inlinable
+  public init(wrappedValue: Path = []) {
+    self = wrappedValue.state
+  }
+
+  @inlinable
+  public var wrappedValue: Path {
+    _read { yield Path(state: self) }
+    _modify {
+      var path = Path(state: self)
+      yield &path
+      self = path.state
+    }
+  }
+
+  @inlinable
+  public var projectedValue: Self {
+    _read { yield self }
+    _modify { yield &self }
+  }
+}
+
+public typealias NavigationStateOf<R: ReducerProtocol> = NavigationState<R.State>
+where R.State: Hashable
+
+extension NavigationState: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (ID, Element)...) {
+    self.destinations = .init(uniqueKeysWithValues: elements)
+  }
+}
+
+extension NavigationState.Destination {
+  private enum CodingKeys: CodingKey {
+    case idTypeName
+    case idString
+    case element
+  }
+}
+
+extension NavigationState.Destination: Decodable where Element: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    if let idTypeName = try? container.decode(String.self, forKey: .idTypeName),
+      let idType = _typeByName(idTypeName),
+      let idString = try? container.decode(String.self, forKey: .idString),
+      let id = try? _decode(idType, from: Data(idString.utf8)) as? AnyHashable
+    {
+      self.id = id
+    } else {
+      self.id = DependencyValues._current.navigationID.next()
+    }
+    self.element = try container.decode(Element.self, forKey: .element)
+  }
+}
+
+extension NavigationState.Destination: Encodable where Element: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    let id = self.id.base
+    if let idData = try? _encode(self.id.base) {
+      try container.encode(_typeName(type(of: id)), forKey: .idTypeName)
+      try container.encode(String(decoding: idData, as: UTF8.self), forKey: .idString)
+    } else if let idData = try? _encode(UUID()) {
+      try container.encode(_typeName(UUID.self), forKey: .idTypeName)
+      try container.encode(String(decoding: idData, as: UTF8.self), forKey: .idString)
+    }
+    try container.encode(element, forKey: .element)
+  }
+}
+
+extension NavigationState.Destination: Equatable where Element: Equatable {}
+extension NavigationState.Destination: Hashable where Element: Hashable {}
+
+extension NavigationState: Equatable where Element: Equatable {}
+extension NavigationState: Hashable where Element: Hashable {}
+
+extension NavigationState: Decodable where Element: Decodable {
+  public init(from decoder: Decoder) throws {
+    try self.init([Destination](from: decoder))
+  }
+}
+extension NavigationState: Encodable where Element: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    try Array(self).encode(to: encoder)
+  }
+}
+
+extension NavigationState.Path: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: Element...) {
+    self.init(elements)
+  }
+}
+
+public enum NavigationAction<State: Hashable, Action> {
+  // TODO: Does it make sense to fold `dismiss` into `element`?
+  case dismiss(id: NavigationState.ID)
+  case element(id: NavigationState.ID, Action)
+  case setPath(NavigationState<State>)
+}
+
+public typealias NavigationActionOf<R: ReducerProtocol> = NavigationAction<R.State, R.Action>
+where R.State: Hashable
+
+extension NavigationAction: Equatable where Action: Equatable {}
+extension NavigationAction: Hashable where Action: Hashable {}
+
+// TODO: Decodable, Encodable, Sendable, ...?
+
+extension ReducerProtocol {
+  @inlinable
+  public func navigationDestination<Destinations: ReducerProtocol>(
+    _ toNavigationState: WritableKeyPath<State, NavigationStateOf<Destinations>>,
+    action toNavigationAction: CasePath<Action, NavigationActionOf<Destinations>>,
+    @ReducerBuilderOf<Destinations> destinations: () -> Destinations,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _NavigationDestinationReducer<Self, Destinations> {
+    .init(
+      base: self,
+      toNavigationState: toNavigationState,
+      toNavigationAction: toNavigationAction,
+      destinations: destinations(),
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+}
+
+public struct _NavigationDestinationReducer<
+  Base: ReducerProtocol,
+  Destinations: ReducerProtocol
+>: ReducerProtocol
+where Destinations.State: Hashable {
+  @usableFromInline
+  let base: Base
+
+  @usableFromInline
+  let toNavigationState: WritableKeyPath<Base.State, NavigationStateOf<Destinations>>
+
+  @usableFromInline
+  let toNavigationAction: CasePath<Base.Action, NavigationActionOf<Destinations>>
+
+  @usableFromInline
+  let destinations: Destinations
+
+  @usableFromInline
+  let file: StaticString
+
+  @usableFromInline
+  let fileID: StaticString
+
+  @usableFromInline
+  let line: UInt
+
+  @usableFromInline
+  enum DismissID {}
+
+  @inlinable
+  init(
+    base: Base,
+    toNavigationState: WritableKeyPath<Base.State, NavigationStateOf<Destinations>>,
+    toNavigationAction: CasePath<Base.Action, NavigationActionOf<Destinations>>,
+    destinations: Destinations,
+    file: StaticString,
+    fileID: StaticString,
+    line: UInt
+  ) {
+    self.base = base
+    self.toNavigationState = toNavigationState
+    self.toNavigationAction = toNavigationAction
+    self.destinations = destinations
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+
+  @inlinable
+  public func reduce(into state: inout Base.State, action: Base.Action) -> EffectTask<Base.Action> {
+    var effect: EffectTask<Base.Action> = .none
+
+    switch self.toNavigationAction.extract(from: action) {
+    case let .dismiss(id):
+      guard let index = state[keyPath: self.toNavigationState].destinations.index(forKey: id)
+      else {
+        runtimeWarn(
+          """
+          A "navigationDestination" at "\(self.fileID):\(self.line)" requested dismissal of a \
+          missing element.
+
+            ID:
+              \(id)
+
+          This is generally considered an application logic error, and can happen for a few \
+          reasons:
+
+          • TODO
+          """,
+          file: self.file,
+          line: self.line
+        )
+        break
+      }
+
+      // TODO:
+      //   Or should dismiss simply remove the element?
+      //   Or should dismiss warn/no-op if the element isn't _the_ presented element?
+      //     (Closest to SwiftUI behavior, which doesn't warn but ignores dismissal)
+      // TODO: Should this delegate to `setPath` instead for parents to listen to?
+      //   Or should parents have to listen to both of these actions or just have the option?
+      state[keyPath: self.toNavigationState].removeSubrange(index...)
+      break
+
+    case let .element(id, localAction):
+      guard let index = state[keyPath: self.toNavigationState].firstIndex(where: { $0.id == id })
+      else {
+        runtimeWarn(
+          """
+          A "navigationDestination" at "\(self.fileID):\(self.line)" received an action for a \
+          missing element.
+
+            Action:
+              \(debugCaseOutput(action))
+
+          This is generally considered an application logic error, and can happen for a few \
+          reasons:
+
+          • TODO
+          """,
+          file: self.file,
+          line: self.line
+        )
+        break
+      }
+      effect = effect.merge(
+        with: self.destinations
+          .dependency(\.dismiss, DismissEffect { Task.cancel(id: DismissID.self) })
+          .dependency(\.navigationID.current, id)
+          .reduce(
+            into: &state[keyPath: self.toNavigationState][index].element,
+            action: localAction
+          )
+          .map { self.toNavigationAction.embed(.element(id: id, $0)) }
+          .cancellable(id: id)
+      )
+
+    // TODO: Track insertions, removals in action for parent to listen to?
+    // .setPath(PathUpdate { newPath: Path, presented: [Element], dismissed: [Element] })
+    case let .setPath(newPath):
+      let oldPath = state[keyPath: self.toNavigationState]
+      let presentedIDs = newPath.ids.subtracting(oldPath.ids)
+      let dismissedIDs = oldPath.ids.subtracting(newPath.ids)
+
+      state[keyPath: self.toNavigationState] = newPath
+
+      for id in presentedIDs {
+        effect = effect.merge(
+          with: .task {
+            var dependencies = DependencyValues._current
+            dependencies.navigationID.current = id
+            return try await DependencyValues.$_current.withValue(dependencies) {
+              try await withTaskCancellation(id: DismissID.self) {
+                try await Task.never()
+              }
+            }
+          }
+          .concatenate(with: Effect(value: self.toNavigationAction.embed(.dismiss(id: id))))
+        )
+      }
+      for id in dismissedIDs {
+        effect = effect.merge(with: .cancel(id: id))
+      }
+
+    case .none:
+      break
+    }
+
+    effect = effect.merge(
+      with: self.base.reduce(into: &state, action: action)
+    )
+
+    return effect
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+public struct NavigationStackStore<Element: Hashable, Content: View>: View {
+  let store: Store<NavigationState<Element>, NavigationState<Element>>
+  let content: Content
+
+  public init<Action>(
+    _ store: Store<NavigationState<Element>, NavigationAction<Element, Action>>,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.store = store.scope(state: { $0 }, action: { .setPath($0) })
+    self.content = content()
+  }
+
+  public var body: some View {
+    WithViewStore(self.store, removeDuplicates: Self.isEqual) { _ in
+      NavigationStack(path: ViewStore(self.store).binding(send: { $0 })) {
+        self.content
+      }
+    }
+  }
+
+  private static func isEqual(
+    lhs: NavigationState<Element>,
+    rhs: NavigationState<Element>
+  ) -> Bool {
+    guard lhs.count == rhs.count
+    else { return false }
+
+    for (lhs, rhs) in zip(lhs, rhs) {
+      guard lhs.id == rhs.id && enumTag(lhs.element) == enumTag(rhs.element)
+      else { return false }
+    }
+    return true
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension View {
+  @ViewBuilder
+  public func navigationDestination<State: Hashable, Action, Content: View>(
+    store: Store<NavigationState<State>, NavigationAction<State, Action>>,
+    @ViewBuilder destination: @escaping (Store<State, Action>) -> Content
+  ) -> some View {
+    self.navigationDestination(for: NavigationState<State>.Destination.self) { state in
+      IfLetStore(
+        store.scope(
+          state: returningLastNonNilValue { $0[id: state.id] ?? state.element },
+          action: { .element(id: state.id, $0) }
+        ),
+        then: destination
+      )
+    }
+  }
+}
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension NavigationLink where Destination == Never {
+  public init<D: Hashable>(state: D?, label: () -> Label) {
+    self.init(
+      value: state.map { NavigationState.Destination(id: UUID(), element: $0) }, label: label)
+  }
+
+  public init<D: Hashable>(_ titleKey: LocalizedStringKey, state: D?) where Label == Text {
+    self.init(titleKey, value: state.map { NavigationState.Destination(id: UUID(), element: $0) })
+  }
+
+  public init<S: StringProtocol, D: Hashable>(_ title: S, state: D?) where Label == Text {
+    self.init(title, value: state.map { NavigationState.Destination(id: UUID(), element: $0) })
+  }
+}

--- a/Sources/ComposableArchitecture/SwiftUI/Presentation.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/Presentation.swift
@@ -1,0 +1,440 @@
+import SwiftUI
+
+// TODO: `@dynamicMemberLookup`? `Sendable where State: Sendable`
+@propertyWrapper
+public enum PresentationState<State> {
+  case dismissed
+  indirect case presented(id: AnyHashable, State)
+
+  public init(wrappedValue: State? = nil) {
+    self =
+      wrappedValue
+      .map { .presented(id: DependencyValues._current.navigationID.next(), $0) }
+      ?? .dismissed
+  }
+
+  public var wrappedValue: State? {
+    _read {
+      switch self {
+      case .dismissed:
+        yield nil
+      case let .presented(_, state):
+        yield state
+      }
+    }
+    _modify {
+      switch self {
+      case .dismissed:
+        var state: State? = nil
+        yield &state
+      case let .presented(id, state):
+        var state: State! = state
+        yield &state
+        self = .presented(id: id, state)
+      }
+    }
+    set {
+      // TODO: Do we need similar for the navigation APIs?
+      // TODO: Should we _always_ reuse the `id` when value is non-nil, even when enum tags differ?
+      guard
+        let newValue = newValue,
+        case let .presented(id, oldValue) = self,
+        enumTag(oldValue) == enumTag(newValue)
+      else {
+        self = .init(wrappedValue: newValue)
+        return
+      }
+
+      self = .presented(id: id, newValue)
+
+      // TODO: Should we add state.$destination.present(...) for explicitly re-presenting new ID?
+      // TODO: Should we do the following instead (we used to)?
+      //self = .init(wrappedValue: newValue)
+    }
+  }
+
+  public var projectedValue: Self {
+    _read { yield self }
+    _modify { yield &self }
+  }
+
+  public var id: AnyHashable? {
+    switch self {
+    case .dismissed:
+      return nil
+    case let .presented(id, _):
+      return id
+    }
+  }
+}
+
+public typealias PresentationStateOf<R: ReducerProtocol> = PresentationState<R.State>
+
+// TODO: Should ID be encodable/decodable ever?
+extension PresentationState: Decodable where State: Decodable {
+  public init(from decoder: Decoder) throws {
+    self.init(wrappedValue: try State?(from: decoder))
+  }
+}
+extension PresentationState: Encodable where State: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    try self.wrappedValue?.encode(to: encoder)
+  }
+}
+
+extension PresentationState: Equatable where State: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.wrappedValue == rhs.wrappedValue
+  }
+}
+extension PresentationState: Hashable where State: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    self.wrappedValue.hash(into: &hasher)
+  }
+}
+
+// TODO: Should ID clutter custom dump logs?
+//extension PresentationState: CustomReflectable {
+//  public var customMirror: Mirror {
+//    Mirror(reflecting: self.wrappedValue as Any)
+//  }
+//}
+
+public enum PresentationAction<State, Action> {
+  case present(id: AnyHashable = DependencyValues._current.uuid(), State? = nil)
+  case presented(Action)
+  case dismiss
+
+  public static var present: Self { .present() }
+}
+
+public typealias PresentationActionOf<R: ReducerProtocol> = PresentationAction<R.State, R.Action>
+
+// TODO:
+//extension PresentationAction: Decodable where State: Decodable, Action: Decodable {}
+//extension PresentationAction: Encodable where State: Encodable, Action: Encodable {}
+
+extension PresentationAction: Equatable where State: Equatable, Action: Equatable {}
+extension PresentationAction: Hashable where State: Hashable, Action: Hashable {}
+
+extension ReducerProtocol {
+  @inlinable
+  public func presentationDestination<Destination: ReducerProtocol>(
+    _ toPresentedState: WritableKeyPath<State, PresentationStateOf<Destination>>,
+    action toPresentedAction: CasePath<Action, PresentationActionOf<Destination>>,
+    @ReducerBuilderOf<Destination> destination: () -> Destination,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _PresentationDestinationReducer<Self, Destination> {
+    _PresentationDestinationReducer(
+      presenter: self,
+      presented: destination(),
+      toPresentedState: toPresentedState,
+      toPresentedAction: toPresentedAction,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+}
+
+public struct _PresentationDestinationReducer<
+  Presenter: ReducerProtocol, Presented: ReducerProtocol
+>: ReducerProtocol {
+  @usableFromInline
+  let presenter: Presenter
+
+  @usableFromInline
+  let presented: Presented
+
+  @usableFromInline
+  let toPresentedState: WritableKeyPath<Presenter.State, PresentationStateOf<Presented>>
+
+  @usableFromInline
+  let toPresentedAction:
+    CasePath<
+      Presenter.Action, PresentationActionOf<Presented>
+    >
+
+  @usableFromInline
+  let file: StaticString
+
+  @usableFromInline
+  let fileID: StaticString
+
+  @usableFromInline
+  let line: UInt
+
+  @usableFromInline
+  enum DismissID {}
+
+  @inlinable
+  init(
+    presenter: Presenter,
+    presented: Presented,
+    toPresentedState: WritableKeyPath<Presenter.State, PresentationStateOf<Presented>>,
+    toPresentedAction: CasePath<Presenter.Action, PresentationActionOf<Presented>>,
+    file: StaticString,
+    fileID: StaticString,
+    line: UInt
+  ) {
+    self.presenter = presenter
+    self.presented = presented
+    self.toPresentedState = toPresentedState
+    self.toPresentedAction = toPresentedAction
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+
+  @inlinable
+  public func reduce(
+    into state: inout Presenter.State, action: Presenter.Action
+  ) -> EffectTask<Presenter.Action> {
+    var effect: EffectTask<Presenter.Action> = .none
+
+    let presentedState = state[keyPath: self.toPresentedState]
+    let presentedAction = self.toPresentedAction.extract(from: action)
+
+    switch presentedAction {
+    case let .present(id, .some(presentedState)):
+      state[keyPath: self.toPresentedState] = .presented(id: id, presentedState)
+
+    case let .presented(presentedAction):
+      if case .presented(let id, var presentedState) = presentedState {
+        defer { state[keyPath: self.toPresentedState] = .presented(id: id, presentedState) }
+        effect = effect.merge(
+          with: self.presented
+            .dependency(\.dismiss, DismissEffect { Task.cancel(id: DismissID.self) })
+            .dependency(\.navigationID.current, id)
+            .reduce(into: &presentedState, action: presentedAction)
+            .map { self.toPresentedAction.embed(.presented($0)) }
+            .cancellable(id: id)
+        )
+      } else {
+        runtimeWarn(
+          """
+          A "presentationDestination" at "\(self.fileID):\(self.line)" received a destination \
+          action when destination state was absent. …
+
+            Action:
+              \(debugCaseOutput(action))
+
+          This is generally considered an application logic error, and can happen for a few \
+          reasons:
+
+          • A parent reducer set destination state to "nil" before this reducer ran. This reducer \
+          must run before any other reducer sets destination state to "nil". This ensures that \
+          destination reducers can handle their actions while their state is still present.
+
+          • This action was sent to the store while destination state was "nil". Make sure that \
+          actions for this reducer can only be sent from a view store when state is present, or \
+          from effects that start from this reducer. In SwiftUI applications, use a Composable \
+          Architecture view modifier like "sheet(store:…)".
+          """,
+          file: self.file,
+          line: self.line
+        )
+        return .none
+      }
+
+    case .present(_, .none), .dismiss, .none:
+      break
+    }
+
+    effect = effect.merge(with: self.presenter.reduce(into: &state, action: action))
+
+    if case .dismiss = presentedAction, case let .presented(id, _) = presentedState {
+      state[keyPath: self.toPresentedState].wrappedValue = nil
+      effect = effect.merge(with: .cancel(id: id))
+    } else if case let .presented(id, _) = presentedState,
+      state[keyPath: self.toPresentedState].id != id
+    {
+      effect = effect.merge(with: .cancel(id: id))
+    }
+
+    if let id = state[keyPath: self.toPresentedState].id, id != presentedState.id {
+      effect = effect.merge(
+        with: .task {
+          var dependencies = DependencyValues._current
+          dependencies.navigationID.current = id
+          return try await DependencyValues.$_current.withValue(dependencies) {
+            try await withTaskCancellation(id: DismissID.self) {
+              try await Task.never()
+            }
+          }
+        }
+        .concatenate(with: Effect(value: self.toPresentedAction.embed(.dismiss)))
+      )
+    }
+
+    return effect
+  }
+}
+
+extension View {
+  @available(iOS 14, tvOS 14, watchOS 7, *)
+  @available(macOS, unavailable)
+  public func fullScreenCover<State, Action, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    @ViewBuilder content: @escaping (Store<State, Action>) -> Content
+  ) -> some View {
+    self.fullScreenCover(store: store, state: { $0 }, action: { $0 }, content: content)
+  }
+
+  @available(iOS 14, tvOS 14, watchOS 7, *)
+  @available(macOS, unavailable)
+  public func fullScreenCover<State, Action, DestinationState, DestinationAction, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    state toDestinationState: @escaping (State) -> DestinationState?,
+    action fromDestinationAction: @escaping (DestinationAction) -> Action,
+    @ViewBuilder content: @escaping (Store<DestinationState, DestinationAction>) -> Content
+  ) -> some View {
+    WithViewStore(store, removeDuplicates: { $0.id == $1.id }) { viewStore in
+      self.fullScreenCover(
+        item: viewStore.binding(
+          get: { Item(destinations: $0, destination: toDestinationState) }, send: .dismiss
+        )
+      ) { _ in
+        IfLetStore(
+          store.scope(
+            state: returningLastNonNilValue { $0.wrappedValue.flatMap(toDestinationState) },
+            action: { .presented(fromDestinationAction($0)) }
+          ),
+          then: content
+        )
+      }
+    }
+  }
+
+  @available(tvOS, unavailable)
+  public func popover<State, Action, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+    arrowEdge: Edge = .top,
+    @ViewBuilder content: @escaping (Store<State, Action>) -> Content
+  ) -> some View {
+    self.popover(
+      store: store,
+      state: { $0 },
+      action: { $0 },
+      attachmentAnchor: attachmentAnchor,
+      arrowEdge: arrowEdge,
+      content: content
+    )
+  }
+
+  @available(tvOS, unavailable)
+  public func popover<State, Action, DestinationState, DestinationAction, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    state toDestinationState: @escaping (State) -> DestinationState?,
+    action fromDestinationAction: @escaping (DestinationAction) -> Action,
+    attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+    arrowEdge: Edge = .top,
+    @ViewBuilder content: @escaping (Store<DestinationState, DestinationAction>) -> Content
+  ) -> some View {
+    WithViewStore(store, removeDuplicates: { $0.id == $1.id }) { viewStore in
+      self.popover(
+        item: viewStore.binding(
+          get: { Item(destinations: $0, destination: toDestinationState) }, send: .dismiss
+        )
+      ) { _ in
+        IfLetStore(
+          store.scope(
+            state: returningLastNonNilValue { $0.wrappedValue.flatMap(toDestinationState) },
+            action: { .presented(fromDestinationAction($0)) }
+          ),
+          then: content
+        )
+      }
+    }
+  }
+
+  public func sheet<State, Action, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    @ViewBuilder content: @escaping (Store<State, Action>) -> Content
+  ) -> some View {
+    self.sheet(store: store, state: { $0 }, action: { $0 }, content: content)
+  }
+
+  public func sheet<State, Action, DestinationState, DestinationAction, Content: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    state toDestinationState: @escaping (State) -> DestinationState?,
+    action fromDestinationAction: @escaping (DestinationAction) -> Action,
+    @ViewBuilder content: @escaping (Store<DestinationState, DestinationAction>) -> Content
+  ) -> some View {
+    WithViewStore(store, removeDuplicates: { $0.id == $1.id }) { viewStore in
+      self.sheet(
+        item: viewStore.binding(
+          get: { Item(destinations: $0, destination: toDestinationState) }, send: .dismiss
+        )
+      ) { _ in
+        IfLetStore(
+          store.scope(
+            state: returningLastNonNilValue { $0.wrappedValue.flatMap(toDestinationState) },
+            action: { .presented(fromDestinationAction($0)) }
+          ),
+          then: content
+        )
+      }
+    }
+  }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  public func navigationDestination<State, Action, Destination: View>(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    @ViewBuilder destination: @escaping (Store<State, Action>) -> Destination
+  ) -> some View {
+    self.navigationDestination(
+      store: store, state: { $0 }, action: { $0 }, destination: destination
+    )
+  }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  public func navigationDestination<
+    State, Action, DestinationState, DestinationAction, Destination: View
+  >(
+    store: Store<PresentationState<State>, PresentationAction<State, Action>>,
+    state toDestinationState: @escaping (State) -> DestinationState?,
+    action fromDestinationAction: @escaping (DestinationAction) -> Action,
+    @ViewBuilder destination: @escaping (Store<DestinationState, DestinationAction>) -> Destination
+  ) -> some View {
+    WithViewStore(
+      store.scope(state: { $0.wrappedValue.flatMap(toDestinationState) != nil })
+    ) { viewStore in
+      self.navigationDestination(
+        isPresented: viewStore.binding(send: { $0 ? .present : .dismiss })
+      ) {
+        IfLetStore(
+          store.scope(
+            state: returningLastNonNilValue { $0.wrappedValue.flatMap(toDestinationState) },
+            action: { .presented(fromDestinationAction($0)) }
+          ),
+          then: destination
+        )
+      }
+    }
+  }
+}
+
+private func areDestinationsEqual<State>(
+  _ lhs: PresentationState<State>,
+  _ rhs: PresentationState<State>
+) -> Bool {
+  lhs.id == rhs.id
+}
+
+private struct Item: Identifiable {
+  let id: AnyHashable
+
+  init?<Destination, Destinations>(
+    destinations: PresentationState<Destinations>,
+    destination toDestination: (Destinations) -> Destination?
+  ) {
+    guard case let .presented(id, destinations) = destinations, toDestination(destinations) != nil
+    else { return nil }
+
+    self.id = id
+  }
+}

--- a/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/SwitchStore.swift
@@ -1235,21 +1235,3 @@ private final class StoreObservableObject<State, Action>: ObservableObject {
     self.wrappedValue = store
   }
 }
-
-private func enumTag<Case>(_ `case`: Case) -> UInt32? {
-  let metadataPtr = unsafeBitCast(type(of: `case`), to: UnsafeRawPointer.self)
-  let kind = metadataPtr.load(as: Int.self)
-  let isEnumOrOptional = kind == 0x201 || kind == 0x202
-  guard isEnumOrOptional else { return nil }
-  let vwtPtr = (metadataPtr - MemoryLayout<UnsafeRawPointer>.size).load(as: UnsafeRawPointer.self)
-  let vwt = vwtPtr.load(as: EnumValueWitnessTable.self)
-  return withUnsafePointer(to: `case`) { vwt.getEnumTag($0, metadataPtr) }
-}
-
-private struct EnumValueWitnessTable {
-  let f1, f2, f3, f4, f5, f6, f7, f8: UnsafeRawPointer
-  let f9, f10: Int
-  let f11, f12: UInt32
-  let getEnumTag: @convention(c) (UnsafeRawPointer, UnsafeRawPointer) -> UInt32
-  let f13, f14: UnsafeRawPointer
-}

--- a/Sources/ComposableArchitecture/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestStore.swift
@@ -51,7 +51,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> Effect<Action, Never> {
+///   ) -> EffectTask<Action> {
 ///     switch action {
 ///     case .decrementButtonTapped:
 ///       state.count -= 1
@@ -110,7 +110,7 @@ import XCTestDynamicOverlay
 ///
 ///   func reduce(
 ///     into state: inout State, action: Action
-///   ) -> Effect<Action, Never> {
+///   ) -> EffectTask<Action> {
 ///     switch action {
 ///     case let .queryChanged(query):
 ///       enum SearchID {}
@@ -221,7 +221,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// The current state.
   ///
   /// When read from a trailing closure assertion in ``send(_:_:file:line:)-6s1gq`` or
-  /// ``receive(_:timeout:_:file:line:)``, it will equal the `inout` state passed to the closure.
+  /// ``receive(_:timeout:_:file:line:)-8yd62``, it will equal the `inout` state passed to the closure.
   public var state: State {
     self.reducer.state
   }
@@ -229,7 +229,7 @@ public final class TestStore<State, Action, ScopedState, ScopedAction, Environme
   /// The timeout to await for in-flight effects.
   ///
   /// This is the default timeout used in all methods that take an optional timeout, such as
-  /// ``receive(_:timeout:_:file:line:)`` and ``finish(timeout:file:line:)``.
+  /// ``receive(_:timeout:_:file:line:)-8yd62`` and ``finish(timeout:file:line:)-7pmv3``.
   public var timeout: UInt64
 
   private var _environment: Box<Environment>
@@ -469,8 +469,8 @@ extension TestStore where ScopedState: Equatable {
   /// Sends an action to the store and asserts when state changes.
   ///
   /// This method suspends in order to allow any effects to start. For example, if you
-  /// track an analytics event in a ``Effect/fireAndForget(priority:_:)`` when an action is sent,
-  /// you can assert on that behavior immediately after awaiting `store.send`:
+  /// track an analytics event in a ``EffectPublisher/fireAndForget(priority:_:)`` when an action is
+  /// sent, you can assert on that behavior immediately after awaiting `store.send`:
   ///
   /// ```swift
   /// @MainActor
@@ -955,7 +955,7 @@ extension TestStore {
 /// await store.send(.stopTimerButtonTapped).finish()
 /// ```
 ///
-/// See ``TestStore/finish(timeout:file:line:)`` for the ability to await all in-flight effects in
+/// See ``TestStore/finish(timeout:file:line:)-7pmv3`` for the ability to await all in-flight effects in
 /// the test store.
 ///
 /// See ``ViewStoreTask`` for the analog provided to ``ViewStore``.
@@ -1068,10 +1068,10 @@ class TestReducer<State, Action>: ReducerProtocol {
     self.state = initialState
   }
 
-  func reduce(into state: inout State, action: TestAction) -> Effect<TestAction, Never> {
+  func reduce(into state: inout State, action: TestAction) -> EffectTask<TestAction> {
     let reducer = self.base.dependency(\.self, self.dependencies)
 
-    let effects: Effect<Action, Never>
+    let effects: EffectTask<Action>
     switch action.origin {
     case let .send(action):
       effects = reducer.reduce(into: &state, action: action)

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -270,8 +270,8 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   /// > Important: ``ViewStore`` is not thread safe and you should only send actions to it from the
   /// > main thread. If you want to send actions on background threads due to the fact that the
   /// > reducer is performing computationally expensive work, then a better way to handle this is to
-  /// > wrap that work in an ``Effect`` that is performed on a background thread so that the result
-  /// > can be fed back into the store.
+  /// > wrap that work in an ``EffectTask`` that is performed on a background thread so that the
+  /// > result can be fed back into the store.
   ///
   /// - Parameter action: An action.
   /// - Returns: A ``ViewStoreTask`` that represents the lifecycle of the effect executed when
@@ -316,7 +316,7 @@ public final class ViewStore<ViewState, ViewAction>: ObservableObject {
   ///   }
   ///   @Dependency(\.fetch) var fetch
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .pulledToRefresh:
   ///       state.isLoading = true

--- a/Sources/Dependencies/Dependencies/MainQueue.swift
+++ b/Sources/Dependencies/Dependencies/MainQueue.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainQueue) var mainQueue
     ///
-    ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/MainRunLoop.swift
+++ b/Sources/Dependencies/Dependencies/MainRunLoop.swift
@@ -26,7 +26,7 @@
     ///
     ///   @Dependency(\.mainRunLoop) var mainRunLoop
     ///
-    ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     ///     switch action {
     ///     case .task:
     ///       return .run { send in

--- a/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
+++ b/Sources/Dependencies/Dependencies/RandomNumberGenerator.swift
@@ -26,7 +26,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.withRandomNumberGenerator) var withRandomNumberGenerator
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .rollDice:
   ///       self.withRandomNumberGenerator { generator in

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -30,7 +30,7 @@ extension DependencyValues {
   ///
   ///   @Dependency(\.uuid) var uuid
   ///
-  ///   func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  ///   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
   ///     switch action {
   ///     case .create:
   ///       state.append(Todo(id: self.uuid())

--- a/Sources/Dependencies/Dependencies/UUID.swift
+++ b/Sources/Dependencies/Dependencies/UUID.swift
@@ -125,15 +125,25 @@ public struct UUIDGenerator: Sendable {
   }
 }
 
-private final class IncrementingUUIDGenerator: @unchecked Sendable {
-  private let lock = NSLock()
+final class IncrementingUUIDGenerator: @unchecked Sendable {
+  private let lock: os_unfair_lock_t
   private var sequence = 0
 
+  init() {
+    self.lock = os_unfair_lock_t.allocate(capacity: 1)
+    self.lock.initialize(to: os_unfair_lock())
+  }
+
+  deinit {
+    self.lock.deinitialize(count: 1)
+    self.lock.deallocate()
+  }
+
   func callAsFunction() -> UUID {
-    self.lock.lock()
+    os_unfair_lock_lock(self.lock)
     defer {
       self.sequence += 1
-      self.lock.unlock()
+      os_unfair_lock_unlock(self.lock)
     }
     return UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012x", self.sequence))")!
   }

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -12,7 +12,7 @@ import XCTestDynamicOverlay
 /// ```
 ///
 /// To change a dependency for a well-defined scope you can use the
-/// ``withValues(_:operation:file:line:)-2atnb`` method:
+/// ``withValues(_:operation:)-1oaja`` method:
 ///
 /// ```swift
 /// @Dependency(\.date) var date

--- a/Sources/swift-composable-architecture-benchmark/Effects.swift
+++ b/Sources/swift-composable-architecture-benchmark/Effects.swift
@@ -5,18 +5,18 @@ import Foundation
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
   $0.benchmark("Merged Effect.none (create, flat)") {
-    doNotOptimizeAway(Effect<Int, Never>.merge((1...100).map { _ in .none }))
+    doNotOptimizeAway(EffectTask<Int>.merge((1...100).map { _ in .none }))
   }
 
   $0.benchmark("Merged Effect.none (create, nested)") {
-    var effect = Effect<Int, Never>.none
+    var effect = EffectTask<Int>.none
     for _ in 1...100 {
       effect = effect.merge(with: .none)
     }
     doNotOptimizeAway(effect)
   }
 
-  let effect = Effect<Int, Never>.merge((1...100).map { _ in .none })
+  let effect = EffectTask<Int>.merge((1...100).map { _ in .none })
   var didComplete = false
   $0.benchmark("Merged Effect.none (sink)") {
     doNotOptimizeAway(

--- a/Sources/swift-composable-architecture-benchmark/StoreScope.swift
+++ b/Sources/swift-composable-architecture-benchmark/StoreScope.swift
@@ -4,7 +4,7 @@ import ComposableArchitecture
 private struct Counter: ReducerProtocol {
   typealias State = Int
   typealias Action = Bool
-  func reduce(into state: inout Int, action: Bool) -> Effect<Bool, Never> {
+  func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
     if action {
       state += 1
       return .none

--- a/Tests/ComposableArchitectureTests/CompatibilityTests.swift
+++ b/Tests/ComposableArchitectureTests/CompatibilityTests.swift
@@ -48,7 +48,7 @@ final class CompatibilityTests: XCTestCase {
           .cancellable(id: cancelID)
 
       case .kickOffAction:
-        return Effect(value: .actionSender(OnDeinit { passThroughSubject.send(.stop) }))
+        return EffectTask(value: .actionSender(OnDeinit { passThroughSubject.send(.stop) }))
 
       case .actionSender:
         return .none

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -16,17 +16,17 @@ final class ComposableArchitectureTests: XCTestCase {
         case squareNow
       }
       @Dependency(\.mainQueue) var mainQueue
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .incrAndSquareLater:
           return .merge(
-            Effect(value: .incrNow)
+            EffectTask(value: .incrNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect(),
-            Effect(value: .squareNow)
+            EffectTask(value: .squareNow)
               .delay(for: 1, scheduler: self.mainQueue)
               .eraseToEffect(),
-            Effect(value: .squareNow)
+            EffectTask(value: .squareNow)
               .delay(for: 2, scheduler: self.mainQueue)
               .eraseToEffect()
           )
@@ -80,8 +80,8 @@ final class ComposableArchitectureTests: XCTestCase {
 
   func testLongLivingEffects() async {
     typealias Environment = (
-      startEffect: Effect<Void, Never>,
-      stopEffect: Effect<Never, Never>
+      startEffect: EffectTask<Void>,
+      stopEffect: EffectTask<Never>
     )
 
     enum Action { case end, incr, start }

--- a/Tests/ComposableArchitectureTests/DebugTests.swift
+++ b/Tests/ComposableArchitectureTests/DebugTests.swift
@@ -207,7 +207,7 @@
       struct DebuggedReducer: ReducerProtocol {
         typealias State = Int
         typealias Action = Bool
-        func reduce(into state: inout Int, action: Bool) -> Effect<Bool, Never> {
+        func reduce(into state: inout Int, action: Bool) -> EffectTask<Bool> {
           state += action ? 1 : -1
           return .none
         }

--- a/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/DependencyKeyWritingReducerTests.swift
@@ -99,7 +99,7 @@ final class DependencyKeyWritingReducerTests: XCTestCase {
       }
       @Dependency(\.myValue) var myValue
 
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           state.count += 1
@@ -136,7 +136,7 @@ private struct Feature: ReducerProtocol {
   @Dependency(\.myValue) var myValue
   struct State: Equatable { var value = 0 }
   enum Action { case tap }
-  func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
     case .tap:
       state.value = self.myValue

--- a/Tests/ComposableArchitectureTests/EffectFailureTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectFailureTests.swift
@@ -13,19 +13,19 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An "Effect.task" returned from \
+          An "EffectTask.task" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.task", or via a "do" block.
+          "EffectTask.task", or via a "do" block.
           """
       }
 
       line = #line
-      let effect = Effect<Void, Never>.task {
+      let effect = EffectTask<Void>.task {
         struct Unexpected: Error {}
         throw Unexpected()
       }
@@ -39,19 +39,19 @@
       var line: UInt!
       XCTExpectFailure {
         $0.compactDescription == """
-          An "Effect.run" returned from \
+          An "EffectTask.run" returned from \
           "ComposableArchitectureTests/EffectFailureTests.swift:\(line+1)" threw an unhandled \
           error. …
 
               EffectFailureTests.Unexpected()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.run", or via a "do" block.
+          "EffectTask.run", or via a "do" block.
           """
       }
 
       line = #line
-      let effect = Effect<Void, Never>.run { _ in
+      let effect = EffectTask<Void>.run { _ in
         struct Unexpected: Error {}
         throw Unexpected()
       }

--- a/Tests/ComposableArchitectureTests/EffectOperationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectOperationTests.swift
@@ -6,7 +6,7 @@
   @MainActor
   class EffectOperationTests: XCTestCase {
     func testMergeDiscardsNones() async {
-      var effect = Effect<Int, Never>.none
+      var effect = EffectTask<Int>.none
         .merge(with: .none)
       switch effect.operation {
       case .none:
@@ -15,7 +15,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.task { 42 }
+      effect = EffectTask<Int>.task { 42 }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -24,7 +24,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectTask<Int>.none
         .merge(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -33,7 +33,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.run { await $0(42) }
+      effect = EffectTask<Int>.run { await $0(42) }
         .merge(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -42,7 +42,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectTask<Int>.none
         .merge(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -53,7 +53,7 @@
     }
 
     func testConcatenateDiscardsNones() async {
-      var effect = Effect<Int, Never>.none
+      var effect = EffectTask<Int>.none
         .concatenate(with: .none)
       switch effect.operation {
       case .none:
@@ -62,7 +62,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.task { 42 }
+      effect = EffectTask<Int>.task { 42 }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -71,7 +71,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectTask<Int>.none
         .concatenate(with: .task { 42 })
       switch effect.operation {
       case let .run(_, send):
@@ -80,7 +80,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.run { await $0(42) }
+      effect = EffectTask<Int>.run { await $0(42) }
         .concatenate(with: .none)
       switch effect.operation {
       case let .run(_, send):
@@ -89,7 +89,7 @@
         XCTFail()
       }
 
-      effect = Effect<Int, Never>.none
+      effect = EffectTask<Int>.none
         .concatenate(with: .run { await $0(42) })
       switch effect.operation {
       case let .run(_, send):
@@ -102,7 +102,7 @@
     func testMergeFuses() async {
       var values = [Int]()
 
-      let effect = Effect<Int, Never>.task {
+      let effect = EffectTask<Int>.task {
         try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         return 42
       }
@@ -125,7 +125,7 @@
     func testConcatenateFuses() async {
       var values = [Int]()
 
-      let effect = Effect<Int, Never>.task { 42 }
+      let effect = EffectTask<Int>.task { 42 }
         .concatenate(with: .task { 1729 })
       switch effect.operation {
       case let .run(_, send):
@@ -138,7 +138,7 @@
     }
 
     func testMap() async {
-      let effect = Effect<Int, Never>.task { 42 }
+      let effect = EffectTask<Int>.task { 42 }
         .map { "\($0)" }
 
       switch effect.operation {

--- a/Tests/ComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectRunTests.swift
@@ -46,13 +46,13 @@ final class EffectRunTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "Effect.run" returned from \
+          An "EffectTask.run" returned from \
           "ComposableArchitectureTests/EffectRunTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectRunTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.run", or via a "do" block.
+          "EffectTask.run", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectTaskTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTaskTests.swift
@@ -46,13 +46,13 @@ final class EffectTaskTests: XCTestCase {
       var line: UInt!
       XCTExpectFailure(nil, enabled: nil, strict: nil) {
         $0.compactDescription == """
-          An "Effect.task" returned from \
+          An "EffectTask.task" returned from \
           "ComposableArchitectureTests/EffectTaskTests.swift:\(line+1)" threw an unhandled error. …
 
               EffectTaskTests.Failure()
 
           All non-cancellation errors must be explicitly handled via the "catch" parameter on \
-          "Effect.task", or via a "do" block.
+          "EffectTask.task", or via a "do" block.
           """
       }
       struct State: Equatable {}

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -292,7 +292,7 @@ final class EffectTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           return .run { send in

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -53,10 +53,10 @@ final class EffectTests: XCTestCase {
   func testConcatenate() {
     var values: [Int] = []
 
-    let effect = Effect<Int, Never>.concatenate(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+    let effect = EffectTask<Int>.concatenate(
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
     )
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
@@ -79,8 +79,8 @@ final class EffectTests: XCTestCase {
   func testConcatenateOneEffect() {
     var values: [Int] = []
 
-    let effect = Effect<Int, Never>.concatenate(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
+    let effect = EffectTask<Int>.concatenate(
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect()
     )
 
     effect.sink(receiveValue: { values.append($0) }).store(in: &self.cancellables)
@@ -95,10 +95,10 @@ final class EffectTests: XCTestCase {
   }
 
   func testMerge() {
-    let effect = Effect<Int, Never>.merge(
-      Effect(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
-      Effect(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
+    let effect = EffectTask<Int>.merge(
+      EffectTask(value: 1).delay(for: 1, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 2).delay(for: 2, scheduler: mainQueue).eraseToEffect(),
+      EffectTask(value: 3).delay(for: 3, scheduler: mainQueue).eraseToEffect()
     )
 
     var values: [Int] = []
@@ -117,7 +117,7 @@ final class EffectTests: XCTestCase {
   }
 
   func testEffectSubscriberInitializer() {
-    let effect = Effect<Int, Never>.run { subscriber in
+    let effect = EffectTask<Int>.run { subscriber in
       subscriber.send(1)
       subscriber.send(2)
       self.mainQueue.schedule(after: self.mainQueue.now.advanced(by: .seconds(1))) {
@@ -154,7 +154,7 @@ final class EffectTests: XCTestCase {
   func testEffectSubscriberInitializer_WithCancellation() {
     enum CancelID {}
 
-    let effect = Effect<Int, Never>.run { subscriber in
+    let effect = EffectTask<Int>.run { subscriber in
       subscriber.send(1)
       self.mainQueue.schedule(after: self.mainQueue.now.advanced(by: .seconds(1))) {
         subscriber.send(2)
@@ -173,7 +173,7 @@ final class EffectTests: XCTestCase {
     XCTAssertEqual(values, [1])
     XCTAssertEqual(isComplete, false)
 
-    Effect<Void, Never>.cancel(id: CancelID.self)
+    EffectTask<Void>.cancel(id: CancelID.self)
       .sink(receiveValue: { _ in })
       .store(in: &self.cancellables)
 
@@ -187,7 +187,7 @@ final class EffectTests: XCTestCase {
     let expectation = self.expectation(description: "Complete")
 
     // This crashes on iOS 13 if Effect.init(error:) is implemented using the Fail publisher.
-    Effect<Never, Error>(error: NSError(domain: "", code: 1))
+    EffectPublisher<Never, Error>(error: NSError(domain: "", code: 1))
       .retry(3)
       .catch { _ in Fail(error: NSError(domain: "", code: 1)) }
       .sink(
@@ -213,7 +213,7 @@ final class EffectTests: XCTestCase {
 
   #if DEBUG
     func testUnimplemented() {
-      let effect = Effect<Never, Never>.unimplemented("unimplemented")
+      let effect = EffectTask<Never>.unimplemented("unimplemented")
       XCTExpectFailure {
         effect
           .sink(receiveValue: { _ in })
@@ -226,7 +226,7 @@ final class EffectTests: XCTestCase {
 
   func testTask() async {
     guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else { return }
-    let effect = Effect<Int, Never>.task { 42 }
+    let effect = EffectTask<Int>.task { 42 }
     for await result in effect.values {
       XCTAssertEqual(result, 42)
     }
@@ -242,7 +242,7 @@ final class EffectTests: XCTestCase {
       return 42
     }
 
-    Effect<Int, Never>.task { await work() }
+    EffectTask<Int>.task { await work() }
       .sink(
         receiveCompletion: { _ in XCTFail() },
         receiveValue: { _ in XCTFail() }
@@ -261,7 +261,7 @@ final class EffectTests: XCTestCase {
         case response(Int)
       }
       @Dependency(\.date) var date
-      func reduce(into state: inout Int, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout Int, action: Action) -> EffectTask<Action> {
         switch action {
         case .tap:
           return .task {
@@ -321,7 +321,7 @@ final class EffectTests: XCTestCase {
     let effect =
       DependencyValues
       .withValue(\.date, .init { Date(timeIntervalSince1970: 1_234_567_890) }) {
-        Effect<Void, Never>(value: ())
+        EffectTask<Void>(value: ())
           .map { date() }
       }
     var output: Date?
@@ -334,7 +334,7 @@ final class EffectTests: XCTestCase {
       let effect =
         DependencyValues
         .withValue(\.date, .init { Date(timeIntervalSince1970: 1_234_567_890) }) {
-          Effect<Void, Never>.task {}
+          EffectTask<Void>.task {}
             .map { date() }
         }
       output = await effect.values.first(where: { _ in true })

--- a/Tests/ComposableArchitectureTests/NavigationTests.swift
+++ b/Tests/ComposableArchitectureTests/NavigationTests.swift
@@ -1,0 +1,47 @@
+import Combine
+import XCTest
+
+@testable import ComposableArchitecture
+
+final class NavigationTests: XCTestCase {
+  func testCodability() throws {
+    struct User: Codable, Hashable {
+      var name: String
+      var bio: String
+    }
+    enum Route: Codable, Hashable {
+      case profile(User)
+    }
+
+    let path: NavigationState<Route> = [
+      1: .profile(.init(name: "Blob", bio: "Blobbed around the world."))
+    ]
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let encoded = try encoder.encode(path)
+    XCTAssertNoDifference(
+      String(decoding: encoded, as: UTF8.self),
+      """
+      [
+        {
+          "element" : {
+            "profile" : {
+              "_0" : {
+                "bio" : "Blobbed around the world.",
+                "name" : "Blob"
+              }
+            }
+          },
+          "idString" : "1",
+          "idTypeName" : "Swift.Int"
+        }
+      ]
+      """
+    )
+    let decoded = try JSONDecoder().decode(NavigationState<Route>.self, from: encoded)
+    XCTAssertNoDifference(
+      decoded,
+      path
+    )
+  }
+}

--- a/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerBuilderTests.swift
@@ -140,7 +140,7 @@ private struct Root: ReducerProtocol {
       case action
     }
 
-    func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
       .none
     }
   }

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -34,7 +34,7 @@ final class ReducerTests: XCTestCase {
       let delay: DispatchQueue.SchedulerTimeType.Stride
       let setValue: @Sendable () async -> Void
 
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         state += 1
         return .fireAndForget {
           try await self.mainQueue.sleep(for: self.delay)
@@ -81,7 +81,7 @@ final class ReducerTests: XCTestCase {
     struct One: ReducerProtocol {
       typealias State = Int
       let effect: @Sendable () async -> Void
-      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         state += 1
         return .fireAndForget {
           await self.effect()

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -18,7 +18,7 @@ final class StoreTests: XCTestCase {
 
   func testCancellableIsRemovedWhenEffectCompletes() {
     let mainQueue = DispatchQueue.test
-    let effect = Effect<Void, Never>(value: ())
+    let effect = EffectTask<Void>(value: ())
       .delay(for: 1, scheduler: mainQueue)
       .eraseToEffect()
 
@@ -185,13 +185,13 @@ final class StoreTests: XCTestCase {
       switch action {
       case .tap:
         return .merge(
-          Effect(value: .next1),
-          Effect(value: .next2),
+          EffectTask(value: .next1),
+          EffectTask(value: .next2),
           .fireAndForget { values.append(1) }
         )
       case .next1:
         return .merge(
-          Effect(value: .end),
+          EffectTask(value: .end),
           .fireAndForget { values.append(2) }
         )
       case .next2:
@@ -214,7 +214,7 @@ final class StoreTests: XCTestCase {
       switch action {
       case .incr:
         state += 1
-        return state >= 100_000 ? Effect(value: .noop) : Effect(value: .incr)
+        return state >= 100_000 ? EffectTask(value: .noop) : EffectTask(value: .incr)
       case .noop:
         return .none
       }
@@ -355,9 +355,9 @@ final class StoreTests: XCTestCase {
         switch action {
         case 0:
           return .merge(
-            Effect(value: 1),
-            Effect(value: 2),
-            Effect(value: 3)
+            EffectTask(value: 1),
+            EffectTask(value: 2),
+            EffectTask(value: 3)
           )
         default:
           state = action

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -17,7 +17,7 @@ final class TestStoreTests: XCTestCase {
       switch action {
       case .a:
         return .merge(
-          Effect.concatenate(.init(value: .b1), .init(value: .c1))
+          EffectTask.concatenate(.init(value: .b1), .init(value: .c1))
             .delay(for: 1, scheduler: mainQueue)
             .eraseToEffect(),
           Empty(completeImmediately: false)
@@ -26,11 +26,11 @@ final class TestStoreTests: XCTestCase {
         )
       case .b1:
         return
-          Effect
+          EffectTask
           .concatenate(.init(value: .b2), .init(value: .b3))
       case .c1:
         return
-          Effect
+          EffectTask
           .concatenate(.init(value: .c2), .init(value: .c3))
       case .b2, .b3, .c2, .c3:
         return .none
@@ -100,7 +100,7 @@ final class TestStoreTests: XCTestCase {
         switch action {
         case .increment:
           state.isChanging = true
-          return Effect(value: .changed(from: state.count, to: state.count + 1))
+          return EffectTask(value: .changed(from: state.count, to: state.count + 1))
         case .changed(let from, let to):
           state.isChanging = false
           if state.count == from {
@@ -145,7 +145,7 @@ final class TestStoreTests: XCTestCase {
       let reducer = Reduce<State, Action> { state, action in
         switch action {
         case .noop:
-          return Effect(value: .finished)
+          return EffectTask(value: .finished)
         case .finished:
           return .none
         }

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -11,7 +11,7 @@ final class TimerTests: XCTestCase {
 
     var count = 0
 
-    Effect.timer(id: 1, every: .seconds(1), on: mainQueue)
+    EffectPublisher.timer(id: 1, every: .seconds(1), on: mainQueue)
       .sink { _ in count += 1 }
       .store(in: &self.cancellables)
 
@@ -34,11 +34,11 @@ final class TimerTests: XCTestCase {
     var count2 = 0
     var count3 = 0
 
-    Effect.merge(
-      Effect.timer(id: 1, every: .seconds(2), on: mainQueue)
+    EffectPublisher.merge(
+      EffectPublisher.timer(id: 1, every: .seconds(2), on: mainQueue)
         .handleEvents(receiveOutput: { _ in count2 += 1 })
         .eraseToEffect(),
-      Effect.timer(id: 2, every: .seconds(3), on: mainQueue)
+      EffectPublisher.timer(id: 2, every: .seconds(3), on: mainQueue)
         .handleEvents(receiveOutput: { _ in count3 += 1 })
         .eraseToEffect()
     )
@@ -67,7 +67,7 @@ final class TimerTests: XCTestCase {
 
     struct CancelToken: Hashable {}
 
-    Effect.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
+    EffectPublisher.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
       .handleEvents(receiveOutput: { _ in firstCount += 1 })
       .eraseToEffect()
       .sink { _ in }
@@ -81,7 +81,7 @@ final class TimerTests: XCTestCase {
 
     XCTAssertEqual(firstCount, 2)
 
-    Effect.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
+    EffectPublisher.timer(id: CancelToken(), every: .seconds(2), on: mainQueue)
       .handleEvents(receiveOutput: { _ in secondCount += 1 })
       .eraseToEffect()
       .sink { _ in }
@@ -103,7 +103,7 @@ final class TimerTests: XCTestCase {
 
     var count = 0
 
-    Effect.timer(id: 1, every: .seconds(1), on: mainQueue)
+    EffectPublisher.timer(id: 1, every: .seconds(1), on: mainQueue)
       .prefix(3)
       .sink { _ in count += 1 }
       .store(in: &self.cancellables)

--- a/Tests/ComposableArchitectureTests/ViewStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/ViewStoreTests.swift
@@ -181,7 +181,7 @@ final class ViewStoreTests: XCTestCase {
           return .none
         case .tapped:
           state = true
-          return Effect(value: .response)
+          return EffectTask(value: .response)
             .receive(on: DispatchQueue.main)
             .eraseToEffect()
         }
@@ -212,7 +212,7 @@ final class ViewStoreTests: XCTestCase {
           return .none
         case .tapped:
           state = true
-          return Effect(value: .response)
+          return EffectTask(value: .response)
             .receive(on: DispatchQueue.main)
             .eraseToEffect()
         }


### PR DESCRIPTION
…rename `Effect` to `EffectPublisher` (pointfreeco#1471)

* Add an `EffectOf<Action>` typealias for `Effect<Action, Never>`

* Fix doc

* Rename `EffectOf` to `EffectTask`

* Rename `Effect` to  `EffectPublisher`

* Soft-deprecate `Effect`

* Link to `EffectTask`

* Use `EffectPublisher` in Combine contexts

* Reword soft-deprecation message

* Remove `renamed:` fix-it for `Effect` deprecation

* Update Sources/ComposableArchitecture/Documentation.docc/Extensions/ReducerProtocol.md

Co-authored-by: Stephen Celis <stephen.celis@gmail.com>

* Update Sources/ComposableArchitecture/Documentation.docc/ComposableArchitecture.md

* Update Sources/ComposableArchitecture/Effect.swift

* Fix DocC identifiers

Co-authored-by: Stephen Celis <stephen.celis@gmail.com>